### PR TITLE
Support requring React Native paths outside of the CLI

### DIFF
--- a/packages/local-cli/.watchmanconfig
+++ b/packages/local-cli/.watchmanconfig
@@ -1,0 +1,5 @@
+{
+  "ignore_dirs": [
+    "node_modules"
+  ]
+}

--- a/packages/local-cli/core/index.js
+++ b/packages/local-cli/core/index.js
@@ -17,6 +17,7 @@ const findAssets = require('./findAssets');
 const ios = require('./ios');
 const wrapCommands = require('./wrapCommands');
 const {ASSET_REGISTRY_PATH} = require('./Constants');
+const findReactNativePath = require('../util/findReactNativePath');
 
 /* $FlowFixMe(>=0.54.0 site=react_native_oss) This comment suppresses an error
  * found when Flow v0.54 was deployed. To see the error delete this comment and
@@ -67,8 +68,7 @@ const pluginPlatforms = plugins.platforms.reduce((acc, pathToPlatforms) => {
 }, {});
 
 const defaultConfig = {
-  // @todo fix
-  // hasteImplModulePath: require.resolve('../../jest/hasteImpl'),
+  hasteImplModulePath: require.resolve(findReactNativePath('jest/hasteImpl')),
 
   getPlatforms(): Array<string> {
     return ['ios', 'android', 'native', ...plugins.haste.platforms];

--- a/packages/local-cli/util/Config.js
+++ b/packages/local-cli/util/Config.js
@@ -10,8 +10,8 @@
 'use strict';
 
 const findSymlinkedModules = require('./findSymlinkedModules');
-// @todo what to do with this file?
-// const getPolyfills = require('../../../react-native/rn-get-polyfills');
+const findReactNativePath = require('./findReactNativePath');
+const getPolyfills = require(findReactNativePath('rn-get-polyfills'));
 const path = require('path');
 
 const {createBlacklist} = require('metro');
@@ -23,17 +23,14 @@ const {loadConfig} = require('metro-config');
 import type {ConfigT} from 'metro-config/src/configTypes.flow';
 
 function getProjectRoot() {
-  if (
-    __dirname.match(/node_modules[\/\\]react-native[\/\\]local-cli[\/\\]util$/)
-  ) {
-    // Packager is running from node_modules.
-    // This is the default case for all projects created using 'react-native init'.
-    return path.resolve(__dirname, '../../../..');
-  } else if (__dirname.match(/Pods[\/\\]React[\/\\]packager$/)) {
-    // React Native was installed using CocoaPods.
+  // React Native was installed using CocoaPods.
+  if (__dirname.match(/Pods[\/\\]React[\/\\]packager$/)) {
+    // @todo check this
     return path.resolve(__dirname, '../../../..');
   }
-  return path.resolve(__dirname, '../..');
+  // Packager is running from node_modules.
+  // This is the default case for all projects created using 'react-native init'.
+  return path.resolve(__dirname, '../../');
 }
 
 const resolveSymlinksForRoots = roots =>
@@ -73,9 +70,9 @@ const Config = {
     },
     serializer: {
       getModulesRunBeforeMainModule: () => [
-        require.resolve('../../Libraries/Core/InitializeCore'),
+        require.resolve(findReactNativePath('Libraries/Core/InitializeCore')),
       ],
-      // getPolyfills,
+      getPolyfills,
     },
     server: {
       port: process.env.RCT_METRO_PORT || 8081,

--- a/packages/local-cli/util/findReactNativePath.js
+++ b/packages/local-cli/util/findReactNativePath.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict
+ */
+
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+
+let reactNativePath = null;
+
+function findReactNativePath(): string {
+  // By default, CLI lives inside `node_modules` next to React Native as 
+  // node dependencies are flattened
+  if (fs.existsSync(path.resolve('../../react-native'))) {
+    return '../../react-native';
+  }
+  // Otherwise, we assume it's within React Native `node_modules`
+  return '../../../';
+}
+
+module.exports = (str) => {
+  if (!reactNativePath) {
+    reactNativePath = findReactNativePath();
+  }
+  return path.join(reactNativePath, str);
+};


### PR DESCRIPTION
CLI still depends on some files from React Native (two, to be specific) and we require them for now. This should be refactored in the future, but I am limiting changes until now to bare minimum.