### PR TITLE
fix: move @babel/core to deps

### DIFF
--- a/packages/local-cli/package.json
+++ b/packages/local-cli/package.json
@@ -21,6 +21,7 @@
     "testEnvironment": "node"
   },
   "dependencies": {
+    "@babel/core": "^7.1.5",
     "@babel/preset-env": "^7.1.5",
     "@babel/preset-flow": "^7.0.0",
     "@babel/register": "^7.0.0",
@@ -62,7 +63,6 @@
     "xmldoc": "^0.4.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.1.5",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "24.0.0-alpha.4",
     "eslint": "^5.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,6 +30,7 @@
 "@babel/core@^7.1.5":
   version "7.1.5"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.1.5.tgz#abb32d7aa247a91756469e788998db6a72b93090"
+  integrity sha512-vOyH020C56tQvte++i+rX2yokZcRfbv/kKcw+/BCRw/cK6dvsr47aCzm8oC1XHwMSEWbqrZKzZRLzLnq6SFMsg==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/generator" "^7.1.5"


### PR DESCRIPTION
`@babel/core` should be in deps, not deve deps, as it's necessary for `@babel/register`