### PR TITLE
Add (very basic) Yarn Plug 'n Play support

### DIFF
--- a/packages/local-cli/util/findReactNativePath.js
+++ b/packages/local-cli/util/findReactNativePath.js
@@ -12,10 +12,21 @@
 
 const path = require('path');
 const fs = require('fs');
+let pnp = null;
+
+try {
+  pnp = require('pnpapi');
+} catch (e) {
+  // Not in PnP
+}
 
 let reactNativePath = null;
 
 function findReactNativePath(): string {
+  // If in PnP, try that first.
+  if (pnp) {
+    return pnp.resolveToUnqualified('react-native', path.join(process.cwd(), '../'))
+  }
   // By default, CLI lives inside `node_modules` next to React Native as 
   // node dependencies are flattened
   if (fs.existsSync(path.join(__dirname, '../../react-native'))) {


### PR DESCRIPTION
This pull request adds very basic support for Yarn PnP in the RN-CLI. It does not yet solve all parts (like the link, native build, bundle, eject) but what this does do is:

 * `global-cli`: If `pnpapi` is present, it will use that to look for the project's `react-native` package instead of looking in `node_modules`. I also tweaked it to look for `react-native-local-cli/cli.js` if it exists.
 * `local-cli`: `findReactNativePath` has been adjusted to support PnP