### PR TITLE
fix: Fix opening dev tools

### DIFF
--- a/packages/local-cli/server/middleware/getDevToolsMiddleware.js
+++ b/packages/local-cli/server/middleware/getDevToolsMiddleware.js
@@ -12,8 +12,8 @@ const launchChrome = require('../util/launchChrome');
 
 const {exec} = require('child_process');
 
-function launchChromeDevTools(host, post, args = '') {
-  var debuggerURL = `http://${host}:${post}/debugger-ui${args}`;
+function launchChromeDevTools(host, port, args = '') {
+  var debuggerURL = `http://${host}:${port}/debugger-ui${args}`;
   console.log('Launching Dev Tools...');
   launchChrome(debuggerURL);
 }

--- a/packages/local-cli/server/middleware/getDevToolsMiddleware.js
+++ b/packages/local-cli/server/middleware/getDevToolsMiddleware.js
@@ -12,8 +12,8 @@ const launchChrome = require('../util/launchChrome');
 
 const {exec} = require('child_process');
 
-function launchChromeDevTools(host, args = '') {
-  var debuggerURL = 'http://' + host + '/debugger-ui' + args;
+function launchChromeDevTools(host, post, args = '') {
+  var debuggerURL = `http://${host}:${post}/debugger-ui${args}`;
   console.log('Launching Dev Tools...');
   launchChrome(debuggerURL);
 }
@@ -23,7 +23,7 @@ function escapePath(pathname) {
   return '"' + pathname + '"';
 }
 
-function launchDevTools({host, watchFolders}, isChromeConnected) {
+function launchDevTools({host, port, watchFolders}, isChromeConnected) {
   // Explicit config always wins
   var customDebugger = process.env.REACT_DEBUGGER;
   if (customDebugger) {
@@ -37,13 +37,12 @@ function launchDevTools({host, watchFolders}, isChromeConnected) {
     });
   } else if (!isChromeConnected()) {
     // Dev tools are not yet open; we need to open a session
-    launchChromeDevTools(host);
+    launchChromeDevTools(host, port);
   }
 }
 
 module.exports = function(options, isChromeConnected) {
   return function(req, res, next) {
-    var host = req.headers.host;
     if (req.url === '/launch-safari-devtools') {
       // TODO: remove `console.log` and dev tools binary
       console.log(
@@ -61,7 +60,7 @@ module.exports = function(options, isChromeConnected) {
       launchDevTools(options, isChromeConnected);
       res.end('OK');
     } else if (req.url === '/launch-js-devtools') {
-      launchDevTools({...options, host}, isChromeConnected);
+      launchDevTools(options, isChromeConnected);
       res.end('OK');
     } else {
       next();

--- a/packages/local-cli/server/middleware/getDevToolsMiddleware.js
+++ b/packages/local-cli/server/middleware/getDevToolsMiddleware.js
@@ -13,32 +13,36 @@ const launchChrome = require('../util/launchChrome');
 const {exec} = require('child_process');
 
 function launchChromeDevTools(host, port, args = '') {
-  var debuggerURL = `http://${host}:${port}/debugger-ui${args}`;
+  const debuggerURL = `http://${host}:${port}/debugger-ui${args}`;
   console.log('Launching Dev Tools...');
   launchChrome(debuggerURL);
 }
 
 function escapePath(pathname) {
   // " Can escape paths with spaces in OS X, Windows, and *nix
-  return '"' + pathname + '"';
+  return `"${pathname}"`;
 }
 
-function launchDevTools({host, port, watchFolders}, isChromeConnected) {
+function launchDevTools({ host, port, watchFolders }, isChromeConnected) {
   // Explicit config always wins
-  var customDebugger = process.env.REACT_DEBUGGER;
+  const customDebugger = process.env.REACT_DEBUGGER;
   if (customDebugger) {
-    var folders = watchFolders.map(escapePath).join(' ');
-    var command = customDebugger + ' ' + folders;
-    console.log('Starting custom debugger by executing: ' + command);
-    exec(command, function(error, stdout, stderr) {
-      if (error !== null) {
-        console.log('Error while starting custom debugger: ' + error);
-      }
-    });
+    customDebugger({ watchFolders, customDebugger });
   } else if (!isChromeConnected()) {
     // Dev tools are not yet open; we need to open a session
     launchChromeDevTools(host, port);
   }
+}
+
+function customDebugger({ watchFolders, customDebugger }) {
+  const folders = watchFolders.map(escapePath).join(' ');
+  const command = `${customDebugger} ${folders}`;
+  console.log('Starting custom debugger by executing:', command);
+  exec(command, function(error, stdout, stderr) {
+    if (error !== null) {
+      console.log('Error while starting custom debugger:', error);
+    }
+  });
 }
 
 module.exports = function(options, isChromeConnected) {

--- a/packages/local-cli/server/server.js
+++ b/packages/local-cli/server/server.js
@@ -37,7 +37,7 @@ module.exports = {
     },
     {
       command: '--host [string]',
-      default: '',
+      default: 'localhost',
     },
     {
       command: '--projectRoot [string]',


### PR DESCRIPTION
## The issue
Opening `dev tools` was causing opening of `chrome` browser on a wrong URL.

## Current behavior
Dev tools are opened on default `port` and `host`. Default `port` is `8081` and `host` is `localhost`.
If you want to change the default behavior, you can do it by providing `--host` and `--port` cmd arguments.
