### PR TITLE
Fix metro config when running from source

### DIFF
--- a/packages/local-cli/util/loadMetroConfig.js
+++ b/packages/local-cli/util/loadMetroConfig.js
@@ -54,8 +54,7 @@ const getDefaultConfig = (root: string) => {
       getModulesRunBeforeMainModule: () => [
         require.resolve('react-native/Libraries/Core/InitializeCore'),
       ],
-      getPolyfills: (...args) =>
-        require('react-native/rn-get-polyfills')(...args),
+      getPolyfills: () => require('react-native/rn-get-polyfills')(),
     },
     server: {
       port: process.env.RCT_METRO_PORT || 8081,
@@ -80,40 +79,6 @@ export type ConfigOptionsT = {
 };
 
 /**
- * Overwrites Metro configuration with options.
- *
- * This ensures that options are always taking precedence over other
- * configuration present.
- */
-const overwriteWithOptions = (config: ConfigT, options: ConfigOptionsT) => {
-  if (options.maxWorkers) {
-    config.maxWorkers = options.maxWorkers;
-  }
-
-  if (options.port) {
-    config.server.port = options.port;
-  }
-
-  if (options.reporter) {
-    config.reporter = options.reporter;
-  }
-
-  if (options.resetCache) {
-    config.resetCache = options.resetCache;
-  }
-
-  if (options.watchFolders) {
-    config.watchFolders = options.watchFolders;
-  }
-
-  if (options.sourceExts && options.sourceExts !== config.resolver.sourceExts) {
-    config.resolver.sourceExts = options.sourceExts.concat(
-      config.resolver.sourceExts
-    );
-  }
-};
-
-/**
  * Loads Metro Config and applies `options` on top of the resolved config.
  *
  * This allows the CLI to always overwrite the file settings.
@@ -127,36 +92,28 @@ module.exports = async function load(
   const config = await loadConfig(
     {
       cwd: projectRoot,
-      config: options.config,
+      ...options,
     },
     defaultConfig
   );
 
   /**
-   * Metro configuration requires the following two properties to be defined
-   * statically. They can't be a function, unline `serializer.getModulesRunBeforeMainModule`.
+   * Workaround for static Metro configuration. If the following properties are defined
+   * in user space, the following code will not run.
    *
-   * We only resolve React Native files if no other value was provided by the user.
-   *
-   * This is to allow using CLI inside React Native source code, where there is no
-   * "react-native" module in "node_modules".
-   *
-   * See "react-native/metro.config.js"
+   * That makes it possible to run CLI in context of `react-native` source code, where
+   * the package does not exist under `node_modules`.
    */
-  if (!config.resolver.hasteImplModulePath) {
+  if (config.resolver.hasteImplModulePath === undefined) {
     config.resolver.hasteImplModulePath = require.resolve(
       'react-native/jest/hasteImpl'
     );
   }
 
-  if (!config.transformer.assetRegistryPath) {
+  if (config.transformer.assetRegistryPath === 'missing-asset-registry-path') {
     config.transformer.assetRegistryPath = require.resolve(
       'react-native/Libraries/Image/AssetRegistry'
     );
-  }
-
-  if (options) {
-    overwriteWithOptions(config, options);
   }
 
   return config;

--- a/packages/local-cli/util/loadMetroConfig.js
+++ b/packages/local-cli/util/loadMetroConfig.js
@@ -150,7 +150,7 @@ module.exports = async function load(
   }
 
   if (!config.transformer.assetRegistryPath) {
-    config.resolver.assetRegistryPath = require.resolve(
+    config.transformer.assetRegistryPath = require.resolve(
       'react-native/Libraries/Image/AssetRegistry'
     );
   }


### PR DESCRIPTION
Metro depends on some private React Native files when starting the server. We are using "require.resolve", which does not work when we actually run CLI from within React Native master (there's no "react-native" package in "node_modules").

I wanted to avoid hacking around "require.resolve" and paths to support that particular use-case. Doing that might become brittle in the future when we add PnP support etc., where "node_modules" awareness might become a problem.

I consider this a temporary hack and hopefully we can do better in the future, e.g. by creating a special package, such as: "react-native-bundler-compat", so that other bundles, such as Webpack can also use these files.

To make this working in React Native, the following "metro.config.js" has to be created:
```
module.exports = {
  serializer: {
    getModulesRunBeforeMainModule: () => [
      require.resolve('./Libraries/Core/InitializeCore'),
    ],
    getPolyfills: require('./rn-get-polyfills'),
  },
  resolver: {
    hasteImplModulePath: require.resolve('./jest/hasteImpl'),
  },
  transformer: {
    assetRegistryPath: require.resolve(
      './Libraries/Image/AssetRegistry'
    ),
  },
};
```
to overwrite the default paths.

Also, fixes #68 as we don't overwrite config ourselves but pass it straight to Metro.