### PR TITLE
Prevent crash in findMatchingSimulator

### DIFF
--- a/packages/local-cli/runIOS/findMatchingSimulator.js
+++ b/packages/local-cli/runIOS/findMatchingSimulator.js
@@ -31,7 +31,7 @@ function findMatchingSimulator(simulators, simulatorString) {
   const parsedSimulatorName = simulatorString
     ? simulatorString.match(/(.*)? (?:\((.*)?\))?/)
     : [];
-  if (parsedSimulatorName[2] !== undefined) {
+  if (parsedSimulatorName && parsedSimulatorName[2] !== undefined) {
     var simulatorVersion = parsedSimulatorName[2];
     var simulatorName = parsedSimulatorName[1];
   } else {


### PR DESCRIPTION
`findMatchingSimulator` could crash if the simulator's name is custom (renamed in Xcode) for ex: `iPhone6v11`.

After this fix it doesn't crash and the correct custom named simulator is chosen.