### PR TITLE
Fix launching chrome dev tools

### DIFF
--- a/packages/local-cli/server/runServer.js
+++ b/packages/local-cli/server/runServer.js
@@ -58,6 +58,7 @@ async function runServer(argv: *, ctx: ContextT, args: Args) {
 
   const middlewareManager = new MiddlewareManager({
     host: args.host,
+    port: metroConfig.server.port,
     watchFolders: metroConfig.watchFolders,
   });
 


### PR DESCRIPTION
We didn't pass the port to the middleware manager which is needed by the `getDevToolsMiddleware` to launch chrome dev tools.