### PR TITLE
fix: --appFolder should only install specific app on Android.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 node_modules
 .vscode
+.idea
 package-lock.json
 npm-debug.log

--- a/packages/local-cli/runAndroid/__tests__/runOnAllDevices.test.js
+++ b/packages/local-cli/runAndroid/__tests__/runOnAllDevices.test.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+jest.mock('child_process', () => ({
+  execFileSync: jest.fn(),
+  spawnSync: jest.fn(),
+}));
+
+jest.mock('../getAdbPath');
+const { execFileSync } = require('child_process');
+
+const runOnAllDevices = require('../runOnAllDevices');
+
+describe('--appFolder', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses appFolder and default variant', () => {
+    runOnAllDevices({
+      appFolder: 'app',
+    });
+
+    expect(execFileSync.mock.calls[0][1]).toContain('app:installDebug');
+  });
+
+  it('uses appFolder and variant', () => {
+    runOnAllDevices({
+      appFolder: 'app',
+      variant: 'debug',
+    });
+
+    expect(execFileSync.mock.calls[0][1]).toContain('app:installDebug');
+
+    runOnAllDevices({
+      appFolder: 'anotherApp',
+      variant: 'staging',
+    });
+
+    expect(execFileSync.mock.calls[1][1]).toContain(
+      'anotherApp:installStaging'
+    );
+  });
+
+  it('uses appFolder and flavor', () => {
+    runOnAllDevices({
+      appFolder: 'app',
+      flavor: 'someFlavor',
+    });
+
+    expect(execFileSync.mock.calls[0][1]).toContain('app:installSomeFlavor');
+  });
+
+  it('uses appFolder and custom installDebug argument', () => {
+    runOnAllDevices({
+      appFolder: 'app',
+      installDebug: 'someRandomCommand',
+    });
+
+    expect(execFileSync.mock.calls[0][1]).toContain('app:someRandomCommand');
+  });
+});

--- a/packages/local-cli/runAndroid/__tests__/runOnAllDevices.test.js
+++ b/packages/local-cli/runAndroid/__tests__/runOnAllDevices.test.js
@@ -22,12 +22,18 @@ describe('--appFolder', () => {
     jest.clearAllMocks();
   });
 
+  it('uses installDebug as default if no arguments', () => {
+    runOnAllDevices({});
+
+    expect(execFileSync.mock.calls[0][1]).toContain('installDebug');
+  });
+
   it('uses appFolder and default variant', () => {
     runOnAllDevices({
-      appFolder: 'app',
+      appFolder: 'someApp',
     });
 
-    expect(execFileSync.mock.calls[0][1]).toContain('app:installDebug');
+    expect(execFileSync.mock.calls[0][1]).toContain('someApp:installDebug');
   });
 
   it('uses appFolder and variant', () => {
@@ -40,10 +46,17 @@ describe('--appFolder', () => {
 
     runOnAllDevices({
       appFolder: 'anotherApp',
+      variant: 'debug',
+    });
+
+    expect(execFileSync.mock.calls[1][1]).toContain('anotherApp:installDebug');
+
+    runOnAllDevices({
+      appFolder: 'anotherApp',
       variant: 'staging',
     });
 
-    expect(execFileSync.mock.calls[1][1]).toContain(
+    expect(execFileSync.mock.calls[2][1]).toContain(
       'anotherApp:installStaging'
     );
   });
@@ -57,12 +70,20 @@ describe('--appFolder', () => {
     expect(execFileSync.mock.calls[0][1]).toContain('app:installSomeFlavor');
   });
 
-  it('uses appFolder and custom installDebug argument', () => {
+  it('uses only installDebug argument', () => {
     runOnAllDevices({
-      appFolder: 'app',
-      installDebug: 'someRandomCommand',
+      installDebug: 'someCommand',
     });
 
-    expect(execFileSync.mock.calls[0][1]).toContain('app:someRandomCommand');
+    expect(execFileSync.mock.calls[0][1]).toContain('someCommand');
+  });
+
+  it('uses appFolder and custom installDebug argument', () => {
+    runOnAllDevices({
+      appFolder: 'anotherApp',
+      installDebug: 'someCommand',
+    });
+
+    expect(execFileSync.mock.calls[0][1]).toContain('anotherApp:someCommand');
   });
 });

--- a/packages/local-cli/runAndroid/getAdbPath.js
+++ b/packages/local-cli/runAndroid/getAdbPath.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+function getAdbPath() {
+  return process.env.ANDROID_HOME
+    ? `${process.env.ANDROID_HOME}/platform-tools/adb`
+    : 'adb';
+}
+
+module.exports = getAdbPath;

--- a/packages/local-cli/runAndroid/runAndroid.js
+++ b/packages/local-cli/runAndroid/runAndroid.js
@@ -85,8 +85,10 @@ function buildAndRun(args) {
   process.chdir(path.join(args.root, 'android'));
   const cmd = process.platform.startsWith('win') ? 'gradlew.bat' : './gradlew';
 
+  // "app" is usually the default value for Android apps with only 1 app
+  const appFolder = args.appFolder || 'app';
   const packageName = fs
-    .readFileSync(`${args.appFolder}/src/main/AndroidManifest.xml`, 'utf8')
+    .readFileSync(`${appFolder}/src/main/AndroidManifest.xml`, 'utf8')
     .match(/package="(.+?)"/)[1];
 
   const packageNameWithSuffix = getPackageNameWithSuffix(
@@ -163,9 +165,9 @@ function buildApk(gradlew) {
 
 function tryInstallAppOnDevice(args, device) {
   try {
-    const pathToApk = `${args.appFolder}/build/outputs/apk/${
-      args.appFolder
-    }-debug.apk`;
+    // "app" is usually the default value for Android apps with only 1 app
+    const appFolder = args.appFolder || 'app';
+    const pathToApk = `${appFolder}/build/outputs/apk/${appFolder}-debug.apk`;
     const adbPath = getAdbPath();
     const adbArgs = ['-s', device, 'install', pathToApk];
     console.log(
@@ -289,8 +291,7 @@ module.exports = {
     {
       command: '--appFolder [string]',
       description:
-        'Specify a different application folder name for the android source.',
-      default: 'app',
+        'Specify a different application folder name for the android source. If not, we assume is "app"',
     },
     {
       command: '--appId [string]',

--- a/packages/local-cli/runAndroid/runAndroid.js
+++ b/packages/local-cli/runAndroid/runAndroid.js
@@ -268,21 +268,25 @@ function runOnAllDevices(
     const gradleArgs = [];
     if (args.variant) {
       gradleArgs.push(
-        `install${args.variant[0].toUpperCase()}${args.variant.slice(1)}`
+        `${
+          args.appFolder
+        }:install${args.variant[0].toUpperCase()}${args.variant.slice(1)}`
       );
     } else if (args.flavor) {
       console.warn(
         chalk.yellow('--flavor has been deprecated. Use --variant instead')
       );
       gradleArgs.push(
-        `install${args.flavor[0].toUpperCase()}${args.flavor.slice(1)}`
+        `${
+          args.appFolder
+        }:install${args.flavor[0].toUpperCase()}${args.flavor.slice(1)}`
       );
     } else {
-      gradleArgs.push('installDebug');
+      gradleArgs.push(`${args.appFolder}:installDebug`);
     }
 
     if (args.installDebug) {
-      gradleArgs.push(args.installDebug);
+      gradleArgs.push(`${args.appFolder}:${args.installDebug}`);
     }
 
     console.log(

--- a/packages/local-cli/runAndroid/runAndroid.js
+++ b/packages/local-cli/runAndroid/runAndroid.js
@@ -17,6 +17,10 @@ const path = require('path');
 const findReactNativeScripts = require('../util/findReactNativeScripts');
 const isPackagerRunning = require('../util/isPackagerRunning');
 const adb = require('./adb');
+const runOnAllDevices = require('./runOnAllDevices');
+const tryRunAdbReverse = require('./tryRunAdbReverse');
+const tryLaunchAppOnDevice = require('./tryLaunchAppOnDevice');
+const getAdbPath = require('./getAdbPath');
 
 // Verifies this is an Android project
 function checkAndroid(root) {
@@ -63,33 +67,6 @@ function runAndroid(argv, config, args) {
     }
     return buildAndRun(args);
   });
-}
-
-function getAdbPath() {
-  return process.env.ANDROID_HOME
-    ? `${process.env.ANDROID_HOME}/platform-tools/adb`
-    : 'adb';
-}
-
-// Runs ADB reverse tcp:8081 tcp:8081 to allow loading the jsbundle from the packager
-function tryRunAdbReverse(packagerPort, device) {
-  try {
-    const adbPath = getAdbPath();
-    const adbArgs = ['reverse', `tcp:${packagerPort}`, `tcp:${packagerPort}`];
-
-    // If a device is specified then tell adb to use it
-    if (device) {
-      adbArgs.unshift('-s', device);
-    }
-
-    console.log(chalk.bold(`Running ${adbPath} ${adbArgs.join(' ')}`));
-
-    execFileSync(adbPath, adbArgs, {
-      stdio: [process.stdin, process.stdout, process.stderr],
-    });
-  } catch (e) {
-    console.log(chalk.yellow(`Could not run adb reverse: ${e.message}`));
-  }
 }
 
 function getPackageNameWithSuffix(appId, appIdSuffix, packageName) {
@@ -209,36 +186,6 @@ function tryInstallAppOnDevice(args, device) {
   }
 }
 
-function tryLaunchAppOnDevice(
-  device,
-  packageNameWithSuffix,
-  packageName,
-  adbPath,
-  mainActivity
-) {
-  try {
-    const adbArgs = [
-      '-s',
-      device,
-      'shell',
-      'am',
-      'start',
-      '-n',
-      `${packageNameWithSuffix}/${packageName}.${mainActivity}`,
-    ];
-    console.log(
-      chalk.bold(
-        `Starting the app on ${device} (${adbPath} ${adbArgs.join(' ')})...`
-      )
-    );
-    spawnSync(adbPath, adbArgs, { stdio: 'inherit' });
-  } catch (e) {
-    console.log(
-      chalk.red('adb invocation failed. Do you have adb in your PATH?')
-    );
-  }
-}
-
 function installAndLaunchOnDevice(
   args,
   selectedDevice,
@@ -255,104 +202,6 @@ function installAndLaunchOnDevice(
     adbPath,
     args.mainActivity
   );
-}
-
-function runOnAllDevices(
-  args,
-  cmd,
-  packageNameWithSuffix,
-  packageName,
-  adbPath
-) {
-  try {
-    const gradleArgs = [];
-    if (args.variant) {
-      gradleArgs.push(
-        `${
-          args.appFolder
-        }:install${args.variant[0].toUpperCase()}${args.variant.slice(1)}`
-      );
-    } else if (args.flavor) {
-      console.warn(
-        chalk.yellow('--flavor has been deprecated. Use --variant instead')
-      );
-      gradleArgs.push(
-        `${
-          args.appFolder
-        }:install${args.flavor[0].toUpperCase()}${args.flavor.slice(1)}`
-      );
-    } else {
-      gradleArgs.push(`${args.appFolder}:installDebug`);
-    }
-
-    if (args.installDebug) {
-      gradleArgs.push(`${args.appFolder}:${args.installDebug}`);
-    }
-
-    console.log(
-      chalk.bold(
-        `Building and installing the app on the device (cd android && ${cmd} ${gradleArgs.join(
-          ' '
-        )})...`
-      )
-    );
-
-    execFileSync(cmd, gradleArgs, {
-      stdio: [process.stdin, process.stdout, process.stderr],
-    });
-  } catch (e) {
-    console.log(
-      chalk.red(
-        'Could not install the app on the device, read the error above for details.\n' +
-          'Make sure you have an Android emulator running or a device connected and have\n' +
-          'set up your Android development environment:\n' +
-          'https://facebook.github.io/react-native/docs/getting-started.html'
-      )
-    );
-    // stderr is automatically piped from the gradle process, so the user
-    // should see the error already, there is no need to do
-    // `console.log(e.stderr)`
-    return Promise.reject(e);
-  }
-  const devices = adb.getDevices();
-  if (devices && devices.length > 0) {
-    devices.forEach(device => {
-      tryRunAdbReverse(args.port, device);
-      tryLaunchAppOnDevice(
-        device,
-        packageNameWithSuffix,
-        packageName,
-        adbPath,
-        args.mainActivity
-      );
-    });
-  } else {
-    try {
-      // If we cannot execute based on adb devices output, fall back to
-      // shell am start
-      const fallbackAdbArgs = [
-        'shell',
-        'am',
-        'start',
-        '-n',
-        `${packageNameWithSuffix}/${packageName}.MainActivity`,
-      ];
-      console.log(
-        chalk.bold(
-          `Starting the app (${adbPath} ${fallbackAdbArgs.join(' ')}...`
-        )
-      );
-      spawnSync(adbPath, fallbackAdbArgs, { stdio: 'inherit' });
-    } catch (e) {
-      console.log(
-        chalk.red('adb invocation failed. Do you have adb in your PATH?')
-      );
-      // stderr is automatically piped from the gradle process, so the user
-      // should see the error already, there is no need to do
-      // `console.log(e.stderr)`
-      return Promise.reject(e);
-    }
-  }
 }
 
 function startServerInNewWindow(port, terminal = process.env.REACT_TERMINAL) {

--- a/packages/local-cli/runAndroid/runOnAllDevices.js
+++ b/packages/local-cli/runAndroid/runOnAllDevices.js
@@ -16,8 +16,8 @@ const adb = require('./adb');
 const tryRunAdbReverse = require('./tryRunAdbReverse');
 const tryLaunchAppOnDevice = require('./tryLaunchAppOnDevice');
 
-function getInstallCommand(appFolder, install = 'install') {
-  return appFolder ? `${appFolder}:${install}` : install;
+function getCommand(appFolder, command) {
+  return appFolder ? `${appFolder}:${command}` : command;
 }
 
 function runOnAllDevices(
@@ -31,11 +31,12 @@ function runOnAllDevices(
     const gradleArgs = [];
 
     if (args.installDebug) {
-      gradleArgs.push(getInstallCommand(args.appFolder, args.installDebug));
+      gradleArgs.push(getCommand(args.appFolder, args.installDebug));
     } else if (args.variant) {
       gradleArgs.push(
-        `${getInstallCommand(
-          args.appFolder
+        `${getCommand(
+          args.appFolder,
+          'install'
         )}${args.variant[0].toUpperCase()}${args.variant.slice(1)}`
       );
     } else if (args.flavor) {
@@ -43,12 +44,13 @@ function runOnAllDevices(
         chalk.yellow('--flavor has been deprecated. Use --variant instead')
       );
       gradleArgs.push(
-        `${getInstallCommand(
-          args.appFolder
+        `${getCommand(
+          args.appFolder,
+          'install'
         )}${args.flavor[0].toUpperCase()}${args.flavor.slice(1)}`
       );
     } else {
-      gradleArgs.push(getInstallCommand(args.appFolder, 'installDebug'));
+      gradleArgs.push(getCommand(args.appFolder, 'installDebug'));
     }
 
     console.log(

--- a/packages/local-cli/runAndroid/runOnAllDevices.js
+++ b/packages/local-cli/runAndroid/runOnAllDevices.js
@@ -16,6 +16,10 @@ const adb = require('./adb');
 const tryRunAdbReverse = require('./tryRunAdbReverse');
 const tryLaunchAppOnDevice = require('./tryLaunchAppOnDevice');
 
+function getInstallCommand(appFolder, install = 'install') {
+  return appFolder ? `${appFolder}:${install}` : install;
+}
+
 function runOnAllDevices(
   args,
   cmd,
@@ -25,27 +29,26 @@ function runOnAllDevices(
 ) {
   try {
     const gradleArgs = [];
-    if (args.variant) {
+
+    if (args.installDebug) {
+      gradleArgs.push(getInstallCommand(args.appFolder, args.installDebug));
+    } else if (args.variant) {
       gradleArgs.push(
-        `${
+        `${getInstallCommand(
           args.appFolder
-        }:install${args.variant[0].toUpperCase()}${args.variant.slice(1)}`
+        )}${args.variant[0].toUpperCase()}${args.variant.slice(1)}`
       );
     } else if (args.flavor) {
       console.warn(
         chalk.yellow('--flavor has been deprecated. Use --variant instead')
       );
       gradleArgs.push(
-        `${
+        `${getInstallCommand(
           args.appFolder
-        }:install${args.flavor[0].toUpperCase()}${args.flavor.slice(1)}`
+        )}${args.flavor[0].toUpperCase()}${args.flavor.slice(1)}`
       );
     } else {
-      gradleArgs.push(`${args.appFolder}:installDebug`);
-    }
-
-    if (args.installDebug) {
-      gradleArgs.push(`${args.appFolder}:${args.installDebug}`);
+      gradleArgs.push(getInstallCommand(args.appFolder, 'installDebug'));
     }
 
     console.log(

--- a/packages/local-cli/runAndroid/runOnAllDevices.js
+++ b/packages/local-cli/runAndroid/runOnAllDevices.js
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/* eslint-disable consistent-return */
+
+const chalk = require('chalk');
+const { spawnSync, execFileSync } = require('child_process');
+
+const adb = require('./adb');
+const tryRunAdbReverse = require('./tryRunAdbReverse');
+const tryLaunchAppOnDevice = require('./tryLaunchAppOnDevice');
+
+function runOnAllDevices(
+  args,
+  cmd,
+  packageNameWithSuffix,
+  packageName,
+  adbPath
+) {
+  try {
+    const gradleArgs = [];
+    if (args.variant) {
+      gradleArgs.push(
+        `${
+          args.appFolder
+        }:install${args.variant[0].toUpperCase()}${args.variant.slice(1)}`
+      );
+    } else if (args.flavor) {
+      console.warn(
+        chalk.yellow('--flavor has been deprecated. Use --variant instead')
+      );
+      gradleArgs.push(
+        `${
+          args.appFolder
+        }:install${args.flavor[0].toUpperCase()}${args.flavor.slice(1)}`
+      );
+    } else {
+      gradleArgs.push(`${args.appFolder}:installDebug`);
+    }
+
+    if (args.installDebug) {
+      gradleArgs.push(`${args.appFolder}:${args.installDebug}`);
+    }
+
+    console.log(
+      chalk.bold(
+        `Building and installing the app on the device (cd android && ${cmd} ${gradleArgs.join(
+          ' '
+        )})...`
+      )
+    );
+
+    execFileSync(cmd, gradleArgs, {
+      stdio: [process.stdin, process.stdout, process.stderr],
+    });
+  } catch (e) {
+    console.log(
+      chalk.red(
+        'Could not install the app on the device, read the error above for details.\n' +
+          'Make sure you have an Android emulator running or a device connected and have\n' +
+          'set up your Android development environment:\n' +
+          'https://facebook.github.io/react-native/docs/getting-started.html'
+      )
+    );
+    // stderr is automatically piped from the gradle process, so the user
+    // should see the error already, there is no need to do
+    // `console.log(e.stderr)`
+    return Promise.reject(e);
+  }
+  const devices = adb.getDevices();
+  if (devices && devices.length > 0) {
+    devices.forEach(device => {
+      tryRunAdbReverse(args.port, device);
+      tryLaunchAppOnDevice(
+        device,
+        packageNameWithSuffix,
+        packageName,
+        adbPath,
+        args.mainActivity
+      );
+    });
+  } else {
+    try {
+      // If we cannot execute based on adb devices output, fall back to
+      // shell am start
+      const fallbackAdbArgs = [
+        'shell',
+        'am',
+        'start',
+        '-n',
+        `${packageNameWithSuffix}/${packageName}.MainActivity`,
+      ];
+      console.log(
+        chalk.bold(
+          `Starting the app (${adbPath} ${fallbackAdbArgs.join(' ')}...`
+        )
+      );
+      spawnSync(adbPath, fallbackAdbArgs, { stdio: 'inherit' });
+    } catch (e) {
+      console.log(
+        chalk.red('adb invocation failed. Do you have adb in your PATH?')
+      );
+      // stderr is automatically piped from the gradle process, so the user
+      // should see the error already, there is no need to do
+      // `console.log(e.stderr)`
+      return Promise.reject(e);
+    }
+  }
+}
+
+module.exports = runOnAllDevices;

--- a/packages/local-cli/runAndroid/tryLaunchAppOnDevice.js
+++ b/packages/local-cli/runAndroid/tryLaunchAppOnDevice.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+const chalk = require('chalk');
+const { spawnSync } = require('child_process');
+
+function tryLaunchAppOnDevice(
+  device,
+  packageNameWithSuffix,
+  packageName,
+  adbPath,
+  mainActivity
+) {
+  try {
+    const adbArgs = [
+      '-s',
+      device,
+      'shell',
+      'am',
+      'start',
+      '-n',
+      `${packageNameWithSuffix}/${packageName}.${mainActivity}`,
+    ];
+    console.log(
+      chalk.bold(
+        `Starting the app on ${device} (${adbPath} ${adbArgs.join(' ')})...`
+      )
+    );
+    spawnSync(adbPath, adbArgs, { stdio: 'inherit' });
+  } catch (e) {
+    console.log(
+      chalk.red('adb invocation failed. Do you have adb in your PATH?')
+    );
+  }
+}
+
+module.exports = tryLaunchAppOnDevice;

--- a/packages/local-cli/runAndroid/tryRunAdbReverse.js
+++ b/packages/local-cli/runAndroid/tryRunAdbReverse.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+const chalk = require('chalk');
+const { execFileSync } = require('child_process');
+
+const getAdbPath = require('./getAdbPath');
+
+// Runs ADB reverse tcp:8081 tcp:8081 to allow loading the jsbundle from the packager
+function tryRunAdbReverse(packagerPort, device) {
+  try {
+    const adbPath = getAdbPath();
+    const adbArgs = ['reverse', `tcp:${packagerPort}`, `tcp:${packagerPort}`];
+
+    // If a device is specified then tell adb to use it
+    if (device) {
+      adbArgs.unshift('-s', device);
+    }
+
+    console.log(chalk.bold(`Running ${adbPath} ${adbArgs.join(' ')}`));
+
+    execFileSync(adbPath, adbArgs, {
+      stdio: [process.stdin, process.stdout, process.stderr],
+    });
+  } catch (e) {
+    console.log(chalk.yellow(`Could not run adb reverse: ${e.message}`));
+  }
+}
+
+module.exports = tryRunAdbReverse;


### PR DESCRIPTION
Fixes #32.

Extracting bunch of functions to its own files too + adding tests.

For not being a breaking change, default behavior (without passing `--appFolder`) will be just to call `installDebug`.