### PR TITLE
fix: android duplicates in linked packages

### DIFF
--- a/packages/local-cli/link/__fixtures__/android/patchedBuild.gradle
+++ b/packages/local-cli/link/__fixtures__/android/patchedBuild.gradle
@@ -13,6 +13,8 @@ dependencies {
     implementation (project(':test-impl-config-spaces')) {
       exclude group: 'com.google.android.gms'
     }
+// Indentation being off for some entries is a part of the test, because
+// Gradle doesn't care about indentation and neither should we
 implementationDebug project(':test-impl-debug')
 implementationAbc project(':test-impl-abc')
    compile project(':test-compile')

--- a/packages/local-cli/link/__fixtures__/android/patchedBuild.gradle
+++ b/packages/local-cli/link/__fixtures__/android/patchedBuild.gradle
@@ -6,10 +6,19 @@
  */
 
 dependencies {
-    implementation project(':test')
-    implementation(project(':test2')) {
+    implementation project(':test-impl')
+    implementation(project(':test-impl-config')) {
       exclude(group: 'org.unwanted', module: 'test10')
     }
+    implementation (project(':test-impl-config-spaces')) {
+      exclude group: 'com.google.android.gms'
+    }
+implementationDebug project(':test-impl-debug')
+implementationAbc project(':test-impl-abc')
+   compile project(':test-compile')
+	 compileDebug project(':test-compile-debug')
+	 compileAbc project(':test-compile-abc')
+
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.android.support:appcompat-v7:27.1.1"
     implementation "com.facebook.react:react-native:+"

--- a/packages/local-cli/link/__tests__/android/isInstalled-test.js
+++ b/packages/local-cli/link/__tests__/android/isInstalled-test.js
@@ -19,11 +19,20 @@ const projectConfig = {
 };
 
 describe('android::isInstalled', () => {
-  it('should return true when project is already in build.gradle', () => {
-    expect(isInstalled(projectConfig, 'test')).toBeTruthy();
-    expect(isInstalled(projectConfig, 'test2')).toBeTruthy();
-  });
-
-  it('should return false when project is not in build.gradle', () =>
-    expect(isInstalled(projectConfig, 'test3')).toBeFalsy());
+  test.each([
+    ['test-impl', true],
+    ['test-impl-config', true],
+    ['test-impl-config-spaces', true],
+    ['test-impl-debug', true],
+    ['test-impl-abc', true],
+    ['test-compile', true],
+    ['test-compile-debug', true],
+    ['test-compile-abc', true],
+    ['test-not-there-yet', false],
+  ])(
+    'properly detects if %p project is already in build.gradle',
+    (project, isPresent) => {
+      expect(isInstalled(projectConfig, project)).toBe(isPresent);
+    }
+  );
 });

--- a/packages/local-cli/link/__tests__/android/makeBuildPatch-test.js
+++ b/packages/local-cli/link/__tests__/android/makeBuildPatch-test.js
@@ -29,8 +29,7 @@ describe('makeBuildPatch', () => {
 
   it('should make a correct install check pattern', () => {
     const { installPattern } = makeBuildPatch(name);
-    const match = `/\\s{4}(implementation)(\\(|\\s)(project)\\(\\':${name}\\'\\)(\\)|\\s)/`;
-    expect(installPattern.toString()).toBe(match);
+    expect(installPattern.toString()).toEqual(expect.stringContaining(name));
   });
 });
 
@@ -44,7 +43,8 @@ describe('makeBuildPatchWithScopedPackage', () => {
 
   it('should make a correct install check pattern', () => {
     const { installPattern } = makeBuildPatch(scopedName);
-    const match = `/\\s{4}(implementation)(\\(|\\s)(project)\\(\\':${normalizedScopedName}\\'\\)(\\)|\\s)/`;
-    expect(installPattern.toString()).toBe(match);
+    expect(installPattern.toString()).toEqual(
+      expect.stringContaining(normalizedScopedName)
+    );
   });
 });

--- a/packages/local-cli/link/__tests__/link-test.js
+++ b/packages/local-cli/link/__tests__/link-test.js
@@ -8,8 +8,7 @@
  * @emails oncall+javascript_foundation
  */
 
-const log = require('npmlog');
-
+jest.mock('npmlog');
 jest.setMock('chalk', { grey: str => str });
 
 const context = {
@@ -19,8 +18,6 @@ const context = {
 describe('link', () => {
   beforeEach(() => {
     jest.resetModules();
-    delete require.cache[require.resolve('../link')];
-    log.level = 'silent';
   });
 
   it('should reject when run in a folder without package.json', done => {

--- a/packages/local-cli/link/android/patches/makeBuildPatch.js
+++ b/packages/local-cli/link/android/patches/makeBuildPatch.js
@@ -12,7 +12,7 @@ const normalizeProjectName = require('./normalizeProjectName');
 module.exports = function makeBuildPatch(name) {
   const normalizedProjectName = normalizeProjectName(name);
   const installPattern = new RegExp(
-    `\\s{4}(implementation)(\\(|\\s)(project)\\(\\':${normalizedProjectName}\\'\\)(\\)|\\s)`
+    `(implementation|compile)\\w*\\s*\\(*project\\(['"]:${normalizedProjectName}['"]\\)`
   );
 
   return {


### PR DESCRIPTION
Fixes #43

- Improved the Regex to be more forgiving in terms of spacing and `implementation`/`compile` names with variants and configs
- add more thorough test
- cleanup makeBuildPatch test to not test implementation details
- cleanup link test so it doesn't output to stdout unnecessarily
- tested on a project I had issues with duplicates (resolved with this diff)

cc @ferrannp 	