### PR TITLE
build: deprecate link all behavior

### DIFF
--- a/packages/local-cli/link/linkAll.js
+++ b/packages/local-cli/link/linkAll.js
@@ -39,13 +39,12 @@ function linkAll(
   );
 
   const tasks = flatten(
-    depenendenciesConfig
-      .map(config => [
-        () => promisify(config.commands.prelink || commandStub),
-        () => linkDependency(platforms, project, config),
-        () => promisify(config.commands.postlink || commandStub),
-        () => linkAssets(platforms, project, assets)
-      ])
+    depenendenciesConfig.map(config => [
+      () => promisify(config.commands.prelink || commandStub),
+      () => linkDependency(platforms, project, config),
+      () => promisify(config.commands.postlink || commandStub),
+      () => linkAssets(platforms, project, assets),
+    ])
   );
 
   return promiseWaterfall(tasks).catch(err => {

--- a/packages/local-cli/link/linkAll.js
+++ b/packages/local-cli/link/linkAll.js
@@ -24,13 +24,17 @@ function linkAll(
   project: ProjectConfigT
 ) {
   log.warn(
-    'Linking modules without specifying package name is deprecated and will be removed in next release'
+    'Running `react-native link` without package name is deprecated and will be removed ' +
+      'in next release. If you are using `react-native link` to link your project assets, ' +
+      ' let us know about your use case here: https://goo.gl/RKTeoc'
   );
+
   const projectAssets = getAssets(context.root);
   const dependencies = getProjectDependencies(context.root);
   const depenendenciesConfig = dependencies.map(dependnecy =>
     getDependencyConfig(context, platforms, dependnecy)
   );
+
   const assets = dedupeAssets(
     depenendenciesConfig.reduce(
       (acc, dependency) => acc.concat(dependency.assets),

--- a/packages/local-cli/link/linkAll.js
+++ b/packages/local-cli/link/linkAll.js
@@ -1,0 +1,53 @@
+// @flow
+
+import type { ContextT, PlatformsT, ProjectConfigT } from '../core/types.flow';
+
+const log = require('npmlog');
+const { uniqBy, flatten } = require('lodash');
+const path = require('path');
+const getProjectDependencies = require('./getProjectDependencies');
+const getDependencyConfig = require('./getDependencyConfig');
+const promiseWaterfall = require('./promiseWaterfall');
+const commandStub = require('./commandStub');
+const promisify = require('./promisify');
+const linkAssets = require('./linkAssets');
+const linkDependency = require('./linkDependency');
+
+log.heading = 'rnpm-link';
+
+const dedupeAssets = assets => uniqBy(assets, asset => path.basename(asset));
+
+function linkAll(
+  context: ContextT,
+  platforms: PlatformsT,
+  project: ProjectConfigT
+) {
+  log.warn(
+    'Linking modules without specifying package name is deprecated and will be removed in next release'
+  );
+  const dependencies = getProjectDependencies(context.root);
+  const depenendenciesConfig = dependencies.map(dependnecy =>
+    getDependencyConfig(context, platforms, dependnecy)
+  );
+  const assets = dedupeAssets(flatten(depenendenciesConfig.map(d => d.assets)));
+
+  const tasks = flatten(
+    depenendenciesConfig
+      .map(config => [
+        () => promisify(config.commands.prelink || commandStub),
+        () => linkDependency(platforms, project, config),
+        () => promisify(config.commands.postlink || commandStub),
+      ])
+      .concat(() => linkAssets(platforms, project, assets))
+  );
+
+  return promiseWaterfall(tasks).catch(err => {
+    log.error(
+      `Something went wrong while linking. Error: ${err.message} \n` +
+        'Please file an issue here: https://github.com/facebook/react-native/issues'
+    );
+    throw err;
+  });
+}
+
+module.exports = linkAll;

--- a/packages/local-cli/link/linkAssets.js
+++ b/packages/local-cli/link/linkAssets.js
@@ -1,0 +1,37 @@
+// @flow
+
+import type { PlatformsT, ProjectConfigT } from '../core/types.flow';
+
+const log = require('npmlog');
+const { isEmpty } = require('lodash');
+
+log.heading = 'rnpm-link';
+
+const linkAssets = (
+  platforms: PlatformsT,
+  project: ProjectConfigT,
+  dependency: *
+) => {
+  if (isEmpty(dependency.assets)) {
+    return;
+  }
+
+  Object.keys(platforms || {}).forEach(platform => {
+    const linkConfig =
+      platforms[platform] &&
+      platforms[platform].linkConfig &&
+      platforms[platform].linkConfig();
+
+    if (!linkConfig || !linkConfig.copyAssets || !project[platform]) {
+      return;
+    }
+
+    log.info(`Linking assets to ${platform} project`);
+    // $FlowFixMe: We check for existence of project[platform]
+    linkConfig.copyAssets(dependency.assets, project[platform]);
+  });
+
+  log.info('Assets have been successfully linked to your project');
+};
+
+module.exports = linkAssets;

--- a/packages/local-cli/link/linkDependency.js
+++ b/packages/local-cli/link/linkDependency.js
@@ -1,0 +1,65 @@
+// @flow
+
+import type { PlatformsT, ProjectConfigT } from '../core/types.flow';
+
+const log = require('npmlog');
+const chalk = require('chalk');
+const pollParams = require('./pollParams');
+
+log.heading = 'rnpm-link';
+
+const linkDependency = async (
+  platforms: PlatformsT,
+  project: ProjectConfigT,
+  dependency: *
+) => {
+  const params = await pollParams(dependency.params);
+
+  Object.keys(platforms || {}).forEach(platform => {
+    if (!project[platform] || !dependency.config[platform]) {
+      return;
+    }
+
+    const linkConfig =
+      platforms[platform] &&
+      platforms[platform].linkConfig &&
+      platforms[platform].linkConfig();
+    if (!linkConfig || !linkConfig.isInstalled || !linkConfig.register) {
+      return;
+    }
+
+    const isInstalled = linkConfig.isInstalled(
+      project[platform],
+      dependency.name,
+      dependency.config[platform]
+    );
+
+    if (isInstalled) {
+      log.info(
+        chalk.grey(
+          `Platform '${platform}' module ${dependency.name} is already linked`
+        )
+      );
+      return;
+    }
+
+    log.info(`Linking ${dependency.name} ${platform} dependency`);
+
+    linkConfig.register(
+      dependency.name,
+      // $FlowFixMe: We check if dependency.config[platform] exists on line 42
+      dependency.config[platform],
+      params,
+      // $FlowFixMe: We check if project[platform] exists on line 42
+      project[platform]
+    );
+
+    log.info(
+      `Platform '${platform}' module ${
+        dependency.name
+      } has been successfully linked`
+    );
+  });
+};
+
+module.exports = linkDependency;


### PR DESCRIPTION
Deprecate `react-native link` without specifying `packageName`.

Tests:
1. Init new project with `react-native init $project_name`
2. Install a couple of native dependencies that need to be linked
3. Invoke `link` command
```
node path/to/cli/packages/local-cli/cli.js link
```

<img width="718" alt="screenshot 2019-01-12 at 13 26 24" src="https://user-images.githubusercontent.com/9092510/51073257-6d735780-166e-11e9-8f1f-b1c6978862f0.png">

Modules are linked correctly but we get deprecation notice.
