### PR TITLE
fix: add newline in package.json

### DIFF
--- a/packages/local-cli/init/init.js
+++ b/packages/local-cli/init/init.js
@@ -114,7 +114,10 @@ function addJestToPackageJson(destinationRoot) {
   packageJSON.jest = {
     preset: 'react-native',
   };
-  fs.writeFileSync(packageJSONPath, JSON.stringify(packageJSON, null, 2));
+  fs.writeFileSync(
+    packageJSONPath,
+    `${JSON.stringify(packageJSON, null, 2)}\n`
+  );
 }
 
 module.exports = init;


### PR DESCRIPTION
The initial version of the package.json file does not contain a newline at the end. This means that the first time a user modifies the file using either an IDE that inserts trailing newlines or using Yarn, the last line will be changed and visible in version control. This is not a big deal, but it is annoying and shows a lack of polish.

I tested this by manually patching this file in a current version of React Native because there is currently no way to test the master of RN and RN cli together.