### PR TITLE
fix: make link understand 'api project'

### DIFF
--- a/packages/local-cli/link/__fixtures__/android/patchedBuild.gradle
+++ b/packages/local-cli/link/__fixtures__/android/patchedBuild.gradle
@@ -21,6 +21,10 @@ implementationAbc project(':test-impl-abc')
 	 compileDebug project(':test-compile-debug')
 	 compileAbc project(':test-compile-abc')
 
+    api project(':test-api')
+    apiDebug project(':test-api-debug')
+    apiAbc project(':test-api-abc')
+
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.android.support:appcompat-v7:27.1.1"
     implementation "com.facebook.react:react-native:+"

--- a/packages/local-cli/link/__tests__/android/isInstalled-test.js
+++ b/packages/local-cli/link/__tests__/android/isInstalled-test.js
@@ -28,6 +28,9 @@ describe('android::isInstalled', () => {
     ['test-compile', true],
     ['test-compile-debug', true],
     ['test-compile-abc', true],
+    ['test-api', true],
+    ['test-api-debug', true],
+    ['test-api-abc', true],
     ['test-not-there-yet', false],
   ])(
     'properly detects if %p project is already in build.gradle',

--- a/packages/local-cli/link/android/patches/makeBuildPatch.js
+++ b/packages/local-cli/link/android/patches/makeBuildPatch.js
@@ -12,7 +12,7 @@ const normalizeProjectName = require('./normalizeProjectName');
 module.exports = function makeBuildPatch(name) {
   const normalizedProjectName = normalizeProjectName(name);
   const installPattern = new RegExp(
-    `(implementation|compile)\\w*\\s*\\(*project\\(['"]:${normalizedProjectName}['"]\\)`
+    `(implementation|api|compile)\\w*\\s*\\(*project\\(['"]:${normalizedProjectName}['"]\\)`
   );
 
   return {


### PR DESCRIPTION
Looking at expo uni modules I've noticed `api` usage in gradle, more on this here: https://medium.com/mindorks/implementation-vs-api-in-gradle-3-0-494c817a6fa

This PR adds support to `api` next to `implementation` and `compile`.