### PR TITLE
build: update xcode version to 2.0.0

### DIFF
--- a/packages/local-cli/package.json
+++ b/packages/local-cli/package.json
@@ -63,7 +63,7 @@
     "serve-static": "^1.13.1",
     "shell-quote": "1.6.1",
     "ws": "^1.1.0",
-    "xcode": "^1.0.0",
+    "xcode": "2.0.0",
     "xmldoc": "^0.4.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5434,7 +5434,7 @@ plist@2.0.1:
     xmlbuilder "8.2.2"
     xmldom "0.1.x"
 
-plist@^3.0.0:
+plist@^3.0.0, plist@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/plist/-/plist-3.0.1.tgz#a9b931d17c304e8912ef0ba3bdd6182baf2e1f8c"
   dependencies:
@@ -6185,6 +6185,15 @@ simple-plist@^0.2.1:
     bplist-parser "0.1.1"
     plist "2.0.1"
 
+simple-plist@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/simple-plist/-/simple-plist-1.0.0.tgz#bed3085633b22f371e111f45d159a1ccf94b81eb"
+  integrity sha512-043L2rO80LVF7zfZ+fqhsEkoJFvW8o59rt/l4ctx1TJWoTx7/jkiS1R5TatD15Z1oYnuLJytzE7gcnnBuIPL2g==
+  dependencies:
+    bplist-creator "0.0.7"
+    bplist-parser "0.1.1"
+    plist "^3.0.1"
+
 sisteransi@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.0.tgz#77d9622ff909080f1c19e5f4a1df0c1b0a27b88c"
@@ -6858,6 +6867,14 @@ ws@^5.2.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
   dependencies:
     async-limiter "~1.0.0"
+
+xcode@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/xcode/-/xcode-2.0.0.tgz#134f1f94c26fbfe8a9aaa9724bfb2772419da1a2"
+  integrity sha512-5xF6RCjAdDEiEsbbZaS/gBRt3jZ/177otZcpoLCjGN/u1LrfgH7/Sgeeavpr/jELpyDqN2im3AKosl2G2W8hfw==
+  dependencies:
+    simple-plist "^1.0.0"
+    uuid "^3.3.2"
 
 xcode@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Update `xcode` package from 1.0.0 to 2.0.0 due to vulnerability issues affecting `plist`. Please, find below excerpt of the Snyk report. 

> LOW SEVERITY
> Regular Expression Denial of Service (ReDoS)
> **Vulnerable module**: plist
> **Introduced through**: react-native@0.57.5
> **Introduced through**: learner-tools-miniapp@0.0.1 › react-native@0.57.5 › xcode@1.0.0 › simple-plist@0.2.1 › plist@2.0.1
>
> **Overview**
> plist is a Mac OS X Plist parser/builder for Node.js and browsers
> 
> Affected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) attacks due to bundling a vulnerable version of the XMLBuilder package. This can cause an impact of about 10 seconds matching time for data 60 characters long.

There are no new tests associated with this change since there are already tests covering `xcode` package. 

