### PR TITLE
Fix: problem on run-android with deviceId

### DIFF
--- a/packages/cli/src/runAndroid/adb.js
+++ b/packages/cli/src/runAndroid/adb.js
@@ -9,7 +9,6 @@
  */
 
 import { execSync, execFileSync } from 'child_process';
-import logger from '../util/logger';
 
 /**
  * Parses the output of the 'adb devices' command
@@ -40,7 +39,6 @@ function getDevices(adbPath: string): Array<string> {
     const devicesResult = execSync(`${adbPath} devices`);
     return parseDevicesResult(devicesResult.toString());
   } catch (e) {
-    logger.error(e.message);
     return [];
   }
 }
@@ -67,7 +65,6 @@ function getAvailableCPUs(adbPath: string, device: string): Array<string> {
 
     return (cpus || '').trim().split(',');
   } catch (e) {
-    logger.error(e.message);
     return [];
   }
 }

--- a/packages/cli/src/runAndroid/adb.js
+++ b/packages/cli/src/runAndroid/adb.js
@@ -5,10 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @flow strict
+ * @flow
  */
 
 const { execSync, execFileSync } = require('child_process');
+const logger = require('../util/logger');
 
 /**
  * Parses the output of the 'adb devices' command
@@ -39,6 +40,7 @@ function getDevices(adbPath: string): Array<string> {
     const devicesResult = execSync(`${adbPath} devices`);
     return parseDevicesResult(devicesResult.toString());
   } catch (e) {
+    logger.error(e.message);
     return [];
   }
 }
@@ -65,6 +67,7 @@ function getAvailableCPUs(adbPath: string, device: string): Array<string> {
 
     return (cpus || '').trim().split(',');
   } catch (e) {
+    logger.error(e.message);
     return [];
   }
 }

--- a/packages/cli/src/runAndroid/runAndroid.js
+++ b/packages/cli/src/runAndroid/runAndroid.js
@@ -76,7 +76,7 @@ function buildAndRun(args) {
   const cmd = process.platform.startsWith('win') ? 'gradlew.bat' : './gradlew';
 
   // "app" is usually the default value for Android apps with only 1 app
-  const appFolder = args.appFolder || 'app';
+  const { appFolder } = args;
   const packageName = fs
     .readFileSync(`${appFolder}/src/main/AndroidManifest.xml`, 'utf8')
     // $FlowFixMe
@@ -158,8 +158,8 @@ function buildApk(gradlew) {
 function tryInstallAppOnDevice(args, adbPath, device) {
   try {
     // "app" is usually the default value for Android apps with only 1 app
-    const appFolder = args.appFolder || 'app';
-    const variant = (args.variant || 'debug').toLowerCase();
+    const { appFolder } = args;
+    const variant = args.variant.toLowerCase();
     const buildDirectory = `${appFolder}/build/outputs/apk/${variant}`;
     const apkFile = getInstallApkName(
       appFolder,
@@ -322,11 +322,13 @@ export default {
     },
     {
       command: '--variant [string]',
+      default: 'debug',
     },
     {
       command: '--appFolder [string]',
       description:
         'Specify a different application folder name for the android source. If not, we assume is "app"',
+      default: 'app',
     },
     {
       command: '--appId [string]',

--- a/packages/cli/src/runAndroid/runOnAllDevices.js
+++ b/packages/cli/src/runAndroid/runOnAllDevices.js
@@ -78,7 +78,7 @@ function runOnAllDevices(
     // `console.log(e.stderr)`
     return Promise.reject(e);
   }
-  const devices = adb.getDevices();
+  const devices = adb.getDevices(adbPath);
   if (devices && devices.length > 0) {
     devices.forEach(device => {
       tryRunAdbReverse(args.port, device);


### PR DESCRIPTION
Fixes #132

- Works well with `enableSeparateBuildPerCPUArchitecture`, `universalApk` options.
- Even if it is already installed, it works normally. (Added -r option to `adb install`)

I hope this helps.
