### PR TITLE
fix: xcode 10.2 compatibility for `run-ios` command

### DIFF
--- a/packages/cli/src/runIOS/findMatchingSimulator.js
+++ b/packages/cli/src/runIOS/findMatchingSimulator.js
@@ -39,7 +39,15 @@ function findMatchingSimulator(simulators, simulatorString) {
   }
 
   let match;
-  for (const version in devices) {
+  for (const versionDescriptor in devices) {
+    const device = devices[versionDescriptor];
+    let version = versionDescriptor;
+
+    if ((/^com\.apple\.CoreSimulator\.SimRuntime\./g).test(version)) {
+      // Transform "com.apple.CoreSimulator.SimRuntime.iOS-12-2" into "iOS 12.2"
+      version = version.replace(/^com\.apple\.CoreSimulator\.SimRuntime\.([^-]+)-([^-]+)-([^-]+)$/g, '$1 $2.$3');
+    }
+
     // Making sure the version of the simulator is an iOS or tvOS (Removes Apple Watch, etc)
     if (!version.startsWith('iOS') && !version.startsWith('tvOS')) {
       continue;
@@ -47,8 +55,8 @@ function findMatchingSimulator(simulators, simulatorString) {
     if (simulatorVersion && !version.endsWith(simulatorVersion)) {
       continue;
     }
-    for (const i in devices[version]) {
-      const simulator = devices[version][i];
+    for (const i in device) {
+      const simulator = device[i];
       // Skipping non-available simulator
       if (
         simulator.availability !== '(available)' &&


### PR DESCRIPTION
Summary:
---------

In Xcode 10.2, the output of `xcrun simctl list --json devices` has changed to include a namespace within each version group. This commit makes a backwards-compatible adjustment to account
for this change in format.

To illustrate:

### `xcrun simctl list --json devices` Output < 10.2

```
{
  "devices": {
    "iOS 10.0": [
      ...
    ]
  }
}
```

### `xcrun simctl list --json devices` Output >= 10.2

```
{
  "devices": {
    "com.apple.CoreSimulator.SimRuntime.iOS-10-0": [
      ...
    ]
  }
}
```

## Test Plan

This is a trivial change that, by human inspection, should clearly be backwards-compatible with the previous code. The question, then, is whether this change addresses the problem of the `run-ios` command not being able to find any simulators on a machine with Xcode 10.2.

Below is the actual output of running `xcrun simctl list --json devices` on my device (running MacOS 10.14.3 and Xcode 10.2 Beta):

```
{
  "devices" : {
    "com.apple.CoreSimulator.SimRuntime.tvOS-12-2" : [
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "Apple TV",
        "udid" : "710A60A1-BD91-42CD-B495-E86BE45D81AF",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "Apple TV 4K",
        "udid" : "8F44F794-520C-4E33-A2AC-D83D0F700CDE",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "Apple TV 4K (at 1080p)",
        "udid" : "FB6BF612-0E9F-499E-B54A-427D945F7FAE",
        "availabilityError" : ""
      }
    ],
    "com.apple.CoreSimulator.SimRuntime.watchOS-5-2" : [
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "Apple Watch Series 2 - 38mm",
        "udid" : "07E0F7A5-7712-4E0A-89B0-5BE507C0E5E3",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "Apple Watch Series 2 - 42mm",
        "udid" : "F74CD080-0ED3-40FE-8D71-01FE4826293F",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "Apple Watch Series 3 - 38mm",
        "udid" : "3A244967-C0F8-4ADF-8DAF-F2CC82CDE7C9",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "Apple Watch Series 3 - 42mm",
        "udid" : "D0E0B1EA-7DC6-47AC-9046-4F02139182E5",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "Apple Watch Series 4 - 40mm",
        "udid" : "E7B393F5-815A-455F-BBEC-4F7178EABE85",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "Apple Watch Series 4 - 44mm",
        "udid" : "CE12177A-CC0B-44EC-B62E-F875F80099B9",
        "availabilityError" : ""
      }
    ],
    "com.apple.CoreSimulator.SimRuntime.iOS-12-2" : [
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPhone 5s",
        "udid" : "E17AF0A7-533C-426D-B4E0-EFDA4D16A2B5",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPhone 6",
        "udid" : "A8CC89E0-CC8E-47BB-8D51-9F1EFBEEFD9E",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPhone 6 Plus",
        "udid" : "1DAF5205-DF32-45BD-B684-1AD08EBA5655",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPhone 6s",
        "udid" : "68D19AF6-B970-48BE-8696-C491A554CEC8",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPhone 6s Plus",
        "udid" : "31DD353A-22CE-4AE8-A430-0162C53C81C6",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPhone 7",
        "udid" : "1D8934E7-0D4E-4FDC-B161-15B8029F168A",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPhone 7 Plus",
        "udid" : "85442982-5548-4B40-A9A7-B56805DFF885",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPhone 8",
        "udid" : "67D5C600-5BE4-4BD8-BF7D-ABE1E8D5FA20",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPhone 8 Plus",
        "udid" : "51743D15-7A5F-4547-9D95-55088057A57A",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPhone SE",
        "udid" : "46995B2C-9585-4D3F-90F4-65AD0B377CBC",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Booted",
        "isAvailable" : true,
        "name" : "iPhone X",
        "udid" : "9FC5B0FE-2C27-459B-AAD7-7792847C8804",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPhone Xs",
        "udid" : "48F0E9F1-6579-4460-AB00-3B7281D469CD",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPhone Xs Max",
        "udid" : "27B5A514-116F-42A4-981E-0C89EC359E0C",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPhone Xʀ",
        "udid" : "32A62842-37C0-40FD-B3DE-3156B0668C43",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPad Air",
        "udid" : "AE05665B-83FF-4CFC-9B89-B8642666955C",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPad Air 2",
        "udid" : "A8006ACA-C49B-4E70-BBC5-83BF5B8E0EFB",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPad (5th generation)",
        "udid" : "434C1308-0F87-4A28-94DE-99CA326A6B44",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPad Pro (9.7-inch)",
        "udid" : "7CB05505-DE0B-48EF-AD6C-47C1C664067D",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPad Pro (12.9-inch)",
        "udid" : "4D4650ED-38BB-4F55-8D4D-D12BC317EA9A",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPad Pro (12.9-inch) (2nd generation)",
        "udid" : "A829E2C3-D504-4209-BF59-6933ECB45CCA",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPad Pro (10.5-inch)",
        "udid" : "A7DF230B-30EE-4124-A0D7-CFB08CDE033E",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPad (6th generation)",
        "udid" : "7A986A5F-51E9-4351-A671-AD314B1F3417",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPad Pro (11-inch)",
        "udid" : "322CB96D-620B-4626-B149-5ED321B9A56F",
        "availabilityError" : ""
      },
      {
        "availability" : "(available)",
        "state" : "Shutdown",
        "isAvailable" : true,
        "name" : "iPad Pro (12.9-inch) (3rd generation)",
        "udid" : "9FA06207-3882-425C-B205-3110D260D8F4",
        "availabilityError" : ""
      }
    ]
  }
}
```