### PR TITLE
fix: improve overall run-ios experience and get rid of CFBundleIdentifier

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -33,7 +33,7 @@ suppress_type=$FlowFixMeProps
 suppress_type=$FlowFixMeState
 
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_ios\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)
-suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\($\\|[^(]\\((\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_ios\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)?:? #[0-9]+
+suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\($\\|[^(]\\|(\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_ios\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
 

--- a/.flowconfig
+++ b/.flowconfig
@@ -33,7 +33,7 @@ suppress_type=$FlowFixMeProps
 suppress_type=$FlowFixMeState
 
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_ios\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)
-suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_ios\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)?:? #[0-9]+
+suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\($\\|[^(]\\((\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_ios\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)?:? #[0-9]+
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
 

--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -27,7 +27,7 @@ commander.version(pkg.version);
 const defaultOptParser = val => val;
 
 const handleError = err => {
-  logger.logError(err);
+  logger.error(err.message);
   process.exit(1);
 };
 
@@ -74,12 +74,12 @@ function printUnknownCommand(cmdName) {
   logger.error(
     [
       cmdName
-        ? `  Unrecognized command "${cmdName}"`
-        : "  You didn't pass any command",
-      `  Run ${chalk.white(
-        'react-native --help'
-      )} to see list of all available commands`,
-    ].join('')
+        ? `Unrecognized command "${cmdName}".`
+        : "You didn't pass any command.",
+      `Run ${chalk.white(
+        '"react-native --help"'
+      )} to see list of all available commands.`,
+    ].join(' ')
   );
 }
 

--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -27,10 +27,7 @@ commander.version(pkg.version);
 const defaultOptParser = val => val;
 
 const handleError = err => {
-  logger.error(err.message || err);
-  if (err.stack) {
-    logger.error(err.stack);
-  }
+  logger.logError(err);
   process.exit(1);
 };
 

--- a/packages/cli/src/core/getPlatforms.js
+++ b/packages/cli/src/core/getPlatforms.js
@@ -35,7 +35,6 @@ module.exports = function getPlatforms(root: string): PlatformsT {
     (acc, pathToPlatform) =>
       Object.assign(
         acc,
-        // $FlowFixMe non-literal require
         require(path.join(root, 'node_modules', pathToPlatform))
       ),
     {}

--- a/packages/cli/src/runIOS/runIOS.js
+++ b/packages/cli/src/runIOS/runIOS.js
@@ -17,7 +17,7 @@ const path = require('path');
 const findXcodeProject = require('./findXcodeProject');
 const parseIOSDevicesList = require('./parseIOSDevicesList');
 const findMatchingSimulator = require('./findMatchingSimulator');
-const { ProcessError } = require('../util/logger');
+const { ProcessError } = require('../util/errors');
 
 type FlagsT = {
   simulator: string,

--- a/packages/cli/src/runIOS/runIOS.js
+++ b/packages/cli/src/runIOS/runIOS.js
@@ -319,8 +319,10 @@ function buildProject(
             [
               `Failed to build iOS project.`,
               `We ran "xcodebuild" command but it exited with error code ${code}.`,
-              `Consider building your app with XCode app to further debug this issue.`,
-            ].join(''),
+              `To debug build logs further, consider building your app with Xcode.app, by opening ${
+                xcodeProject.name
+              }`,
+            ].join(' '),
             errorOutput
           )
         );

--- a/packages/cli/src/runIOS/runIOS.js
+++ b/packages/cli/src/runIOS/runIOS.js
@@ -21,7 +21,7 @@ const { ProcessError } = require('../util/logger');
 
 type FlagsT = {
   simulator: string,
-  configuration: ?string,
+  configuration: string,
   scheme: ?string,
   projectPath: string,
   device: ?string,
@@ -80,7 +80,7 @@ function runIOS(_: Array<string>, ctx: ContextT, args: FlagsT) {
       );
     }
     if (devices && devices.length > 0) {
-      // $FlowIssue: `args.device` is never null here
+      // $FlowIssue: args.device is defined in this context
       console.log(`Could not find device with the name: "${args.device}".`);
       console.log('Choose one of the following:');
       printFoundDevices(devices);
@@ -88,13 +88,19 @@ function runIOS(_: Array<string>, ctx: ContextT, args: FlagsT) {
       console.log('No iOS devices connected.');
     }
   } else if (args.udid) {
+    // $FlowIssue: args.udid is defined in this context
     return runOnDeviceByUdid(args, scheme, xcodeProject, devices);
   }
 
   return runOnSimulator(xcodeProject, args, scheme);
 }
 
-function runOnDeviceByUdid(args, scheme, xcodeProject, devices) {
+function runOnDeviceByUdid(
+  args: FlagsT & { udid: string },
+  scheme,
+  xcodeProject,
+  devices
+) {
   const selectedDevice = matchingDeviceByUdid(devices, args.udid);
 
   if (selectedDevice) {
@@ -111,6 +117,7 @@ function runOnDeviceByUdid(args, scheme, xcodeProject, devices) {
   }
 
   if (devices && devices.length > 0) {
+    // $FlowIssue: args.udid is defined in this context
     console.log(`Could not find device with the udid: "${args.udid}".`);
     console.log('Choose one of the following:');
     printFoundDevices(devices);
@@ -257,7 +264,7 @@ function buildProject(
   xcodeProject,
   udid,
   scheme,
-  configuration = 'Debug',
+  configuration,
   launchPackager = false,
   verbose,
   port
@@ -339,7 +346,7 @@ function bootSimulator(selectedSimulator) {
   }
 }
 
-function getBuildPath(configuration = 'Debug', appName, isDevice, scheme) {
+function getBuildPath(configuration, appName, isDevice, scheme) {
   let device;
 
   if (isDevice) {
@@ -456,6 +463,7 @@ module.exports = {
     {
       command: '--configuration [string]',
       description: 'Explicitly set the scheme configuration to use',
+      default: 'Debug',
     },
     {
       command: '--scheme [string]',

--- a/packages/cli/src/runIOS/runIOS.js
+++ b/packages/cli/src/runIOS/runIOS.js
@@ -4,62 +4,47 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow
  * @format
  */
 
-/* eslint-disable */
+import type { ContextT } from '../core/types.flow';
 
+// eslint-disable-next-line
 const child_process = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const findXcodeProject = require('./findXcodeProject');
-const findReactNativeScripts = require('../util/findReactNativeScripts');
 const parseIOSDevicesList = require('./parseIOSDevicesList');
 const findMatchingSimulator = require('./findMatchingSimulator');
+const { ProcessError } = require('../util/logger');
 
-const getBuildPath = function(configuration = 'Debug', appName, isDevice, scheme) {
-  let device;
-
-  if (isDevice) {
-    device = 'iphoneos';
-  } else if (appName.toLowerCase().includes('tvos')) {
-    device = 'appletvsimulator';
-  } else {
-    device = 'iphonesimulator';
-  }
-
-  return `build/${scheme}/Build/Products/${configuration}-${device}/${appName}.app`;
-};
-const xcprettyAvailable = function() {
-  try {
-    child_process.execSync('xcpretty --version', {
-      stdio: [0, 'pipe', 'ignore'],
-    });
-  } catch (error) {
-    return false;
-  }
-  return true;
+type FlagsT = {
+  simulator: string,
+  configuration: ?string,
+  scheme: ?string,
+  projectPath: string,
+  device: ?string,
+  udid: ?string,
+  packager: boolean,
+  verbose: boolean,
+  port: number,
 };
 
-function runIOS(argv, config, args) {
+function runIOS(_: Array<string>, ctx: ContextT, args: FlagsT) {
   if (!fs.existsSync(args.projectPath)) {
-    const reactNativeScriptsPath = findReactNativeScripts();
-    if (reactNativeScriptsPath) {
-      child_process.spawnSync(
-        reactNativeScriptsPath,
-        ['ios'].concat(process.argv.slice(1)),
-        { stdio: 'inherit' }
-      );
-      return;
-    }
     throw new Error(
       'iOS project folder not found. Are you sure this is a React Native project?'
     );
   }
+
   process.chdir(args.projectPath);
+
   const xcodeProject = findXcodeProject(fs.readdirSync('.'));
   if (!xcodeProject) {
-    throw new Error('Could not find Xcode project files in ios folder');
+    throw new Error(
+      `Could not find Xcode project files in "${args.projectPath}" folder`
+    );
   }
 
   const inferredSchemeName = path.basename(
@@ -67,16 +52,20 @@ function runIOS(argv, config, args) {
     path.extname(xcodeProject.name)
   );
   const scheme = args.scheme || inferredSchemeName;
+
   console.log(
     `Found Xcode ${xcodeProject.isWorkspace ? 'workspace' : 'project'} ${
       xcodeProject.name
     }`
   );
+
   const devices = parseIOSDevicesList(
+    // $FlowExpectedError https://github.com/facebook/flow/issues/5675
     child_process.execFileSync('xcrun', ['instruments', '-s'], {
       encoding: 'utf8',
     })
   );
+
   if (args.device) {
     const selectedDevice = matchingDevice(devices, args.device);
     if (selectedDevice) {
@@ -91,6 +80,7 @@ function runIOS(argv, config, args) {
       );
     }
     if (devices && devices.length > 0) {
+      // $FlowIssue: `args.device` is never null here
       console.log(`Could not find device with the name: "${args.device}".`);
       console.log('Choose one of the following:');
       printFoundDevices(devices);
@@ -99,15 +89,16 @@ function runIOS(argv, config, args) {
     }
   } else if (args.udid) {
     return runOnDeviceByUdid(args, scheme, xcodeProject, devices);
-  } else {
-    return runOnSimulator(xcodeProject, args, scheme);
   }
+
+  return runOnSimulator(xcodeProject, args, scheme);
 }
 
 function runOnDeviceByUdid(args, scheme, xcodeProject, devices) {
   const selectedDevice = matchingDeviceByUdid(devices, args.udid);
+
   if (selectedDevice) {
-    return runOnDevice(
+    runOnDevice(
       selectedDevice,
       scheme,
       xcodeProject,
@@ -116,7 +107,9 @@ function runOnDeviceByUdid(args, scheme, xcodeProject, devices) {
       args.verbose,
       args.port
     );
+    return;
   }
+
   if (devices && devices.length > 0) {
     console.log(`Could not find device with the udid: "${args.udid}".`);
     console.log('Choose one of the following:');
@@ -126,96 +119,96 @@ function runOnDeviceByUdid(args, scheme, xcodeProject, devices) {
   }
 }
 
-function runOnSimulator(xcodeProject, args, scheme) {
-  return new Promise(resolve => {
-    try {
-      var simulators = JSON.parse(
-        child_process.execFileSync(
-          'xcrun',
-          ['simctl', 'list', '--json', 'devices'],
-          { encoding: 'utf8' }
-        )
-      );
-    } catch (e) {
-      throw new Error('Could not parse the simulator list output');
-    }
-
-    const selectedSimulator = findMatchingSimulator(simulators, args.simulator);
-    if (!selectedSimulator) {
-      throw new Error(`Could not find ${args.simulator} simulator`);
-    }
-
-    /**
-     * Booting simulator through `xcrun simctl boot` will boot it in the `headless` mode
-     * (running in the background).
-     *
-     * In order for user to see the app and the simulator itself, we have to make sure
-     * that the Simulator.app is running.
-     *
-     * We also pass it `-CurrentDeviceUDID` so that when we launch it for the first time,
-     * it will not boot the "default" device, but the one we set. If the app is already running,
-     * this flag has no effect.
-     */
-    const activeDeveloperDir = child_process
-      .execFileSync('xcode-select', ['-p'], { encoding: 'utf8' })
-      .trim();
-    child_process.execFileSync('open', [
-      `${activeDeveloperDir}/Applications/Simulator.app`,
-      '--args',
-      '-CurrentDeviceUDID',
-      selectedSimulator.udid,
-    ]);
-
-    if (!selectedSimulator.booted) {
-      const simulatorFullName = formattedDeviceName(selectedSimulator);
-      console.log(`Launching ${simulatorFullName}...`);
-      try {
-        child_process.spawnSync('xcrun', [
-          'instruments',
-          '-w',
-          selectedSimulator.udid,
-        ]);
-      } catch (e) {
-        // instruments always fail with 255 because it expects more arguments,
-        // but we want it to only launch the simulator
-      }
-    }
-
-    buildProject(
-      xcodeProject,
-      selectedSimulator.udid,
-      scheme,
-      args.configuration,
-      args.packager,
-      args.verbose,
-      args.port
-    ).then(appName => resolve({ udid: selectedSimulator.udid, appName }));
-  }).then(({ udid, appName }) => {
-    if (!appName) {
-      appName = scheme;
-    }
-    const appPath = getBuildPath(args.configuration, appName, false, scheme);
-    console.log(`Installing ${appPath}`);
-    child_process.spawnSync('xcrun', ['simctl', 'install', udid, appPath], {
-      stdio: 'inherit',
-    });
-
-    const bundleID = child_process
-      .execFileSync(
-        '/usr/libexec/PlistBuddy',
-        ['-c', 'Print:CFBundleIdentifier', path.join(appPath, 'Info.plist')],
+async function runOnSimulator(xcodeProject, args, scheme) {
+  let simulators;
+  try {
+    simulators = JSON.parse(
+      // $FlowIssue: https://github.com/facebook/flow/issues/5675
+      child_process.execFileSync(
+        'xcrun',
+        ['simctl', 'list', '--json', 'devices'],
         { encoding: 'utf8' }
       )
-      .trim();
+    );
+  } catch (e) {
+    throw new Error('Could not parse the simulator list output');
+  }
 
-    console.log(`Launching ${bundleID}`);
-    child_process.spawnSync('xcrun', ['simctl', 'launch', udid, bundleID], {
+  const selectedSimulator = findMatchingSimulator(simulators, args.simulator);
+  if (!selectedSimulator) {
+    throw new Error(`Could not find ${args.simulator} simulator`);
+  }
+
+  /**
+   * Booting simulator through `xcrun simctl boot` will boot it in the `headless` mode
+   * (running in the background).
+   *
+   * In order for user to see the app and the simulator itself, we have to make sure
+   * that the Simulator.app is running.
+   *
+   * We also pass it `-CurrentDeviceUDID` so that when we launch it for the first time,
+   * it will not boot the "default" device, but the one we set. If the app is already running,
+   * this flag has no effect.
+   */
+  const activeDeveloperDir = child_process
+    .execFileSync('xcode-select', ['-p'], { encoding: 'utf8' })
+    // $FlowExpectedError https://github.com/facebook/flow/issues/5675
+    .trim();
+
+  child_process.execFileSync('open', [
+    `${activeDeveloperDir}/Applications/Simulator.app`,
+    '--args',
+    '-CurrentDeviceUDID',
+    selectedSimulator.udid,
+  ]);
+
+  if (!selectedSimulator.booted) {
+    bootSimulator(selectedSimulator);
+  }
+
+  const appName = await buildProject(
+    xcodeProject,
+    selectedSimulator.udid,
+    scheme,
+    args.configuration,
+    args.packager,
+    args.verbose,
+    args.port
+  );
+
+  const appPath = getBuildPath(args.configuration, appName, false, scheme);
+
+  console.log(`Installing ${appPath}`);
+
+  child_process.spawnSync(
+    'xcrun',
+    ['simctl', 'install', selectedSimulator.udid, appPath],
+    {
       stdio: 'inherit',
-    });
-  });
+    }
+  );
+
+  const bundleID = child_process
+    .execFileSync(
+      '/usr/libexec/PlistBuddy',
+      ['-c', 'Print:CFBundleIdentifier', path.join(appPath, 'Info.plist')],
+      { encoding: 'utf8' }
+    )
+    // $FlowExpectedError https://github.com/facebook/flow/issues/5675
+    .trim();
+
+  console.log(`Launching ${bundleID}`);
+
+  child_process.spawnSync(
+    'xcrun',
+    ['simctl', 'launch', selectedSimulator.udid, bundleID],
+    {
+      stdio: 'inherit',
+    }
+  );
 }
 
-function runOnDevice(
+async function runOnDevice(
   selectedDevice,
   scheme,
   xcodeProject,
@@ -224,7 +217,7 @@ function runOnDevice(
   verbose,
   port
 ) {
-  return buildProject(
+  const appName = await buildProject(
     xcodeProject,
     selectedDevice.udid,
     scheme,
@@ -232,34 +225,32 @@ function runOnDevice(
     launchPackager,
     verbose,
     port
-  ).then(appName => {
-    if (!appName) {
-      appName = scheme;
-    }
-    const iosDeployInstallArgs = [
-      '--bundle',
-      getBuildPath(configuration, appName, true, scheme),
-      '--id',
-      selectedDevice.udid,
-      '--justlaunch',
-    ];
-    console.log(
-      `installing and launching your app on ${selectedDevice.name}...`
-    );
-    const iosDeployOutput = child_process.spawnSync(
-      'ios-deploy',
-      iosDeployInstallArgs,
-      { encoding: 'utf8' }
-    );
-    if (iosDeployOutput.error) {
-      console.log('');
-      console.log('** INSTALLATION FAILED **');
-      console.log('Make sure you have ios-deploy installed globally.');
-      console.log('(e.g "npm install -g ios-deploy")');
-    } else {
-      console.log('** INSTALLATION SUCCEEDED **');
-    }
-  });
+  );
+
+  const iosDeployInstallArgs = [
+    '--bundle',
+    getBuildPath(configuration, appName, true, scheme),
+    '--id',
+    selectedDevice.udid,
+    '--justlaunch',
+  ];
+
+  console.log(`installing and launching your app on ${selectedDevice.name}...`);
+
+  const iosDeployOutput = child_process.spawnSync(
+    'ios-deploy',
+    iosDeployInstallArgs,
+    { encoding: 'utf8' }
+  );
+
+  if (iosDeployOutput.error) {
+    console.log('');
+    console.log('** INSTALLATION FAILED **');
+    console.log('Make sure you have ios-deploy installed globally.');
+    console.log('(e.g "npm install -g ios-deploy")');
+  } else {
+    console.log('** INSTALLATION SUCCEEDED **');
+  }
 }
 
 function buildProject(
@@ -299,6 +290,7 @@ function buildProject(
       getProcessOptions(launchPackager, port)
     );
     let buildOutput = '';
+    let errorOutput = '';
     buildProcess.stdout.on('data', data => {
       buildOutput += data.toString();
       if (xcpretty) {
@@ -308,26 +300,75 @@ function buildProject(
       }
     });
     buildProcess.stderr.on('data', data => {
-      console.error(data.toString());
+      errorOutput += data;
     });
     buildProcess.on('close', code => {
       if (xcpretty) {
         xcpretty.stdin.end();
       }
-      // FULL_PRODUCT_NAME is the actual file name of the app, which actually comes from the Product Name in the build config, which does not necessary match a scheme name,  example output line: export FULL_PRODUCT_NAME="Super App Dev.app"
-      const productNameMatch = /export FULL_PRODUCT_NAME="?(.+).app"?$/m.exec(
-        buildOutput
-      );
-      if (
-        productNameMatch &&
-        productNameMatch.length &&
-        productNameMatch.length > 1
-      ) {
-        return resolve(productNameMatch[1]); // 0 is the full match, 1 is the app name
+      if (code !== 0) {
+        reject(
+          new ProcessError(
+            [
+              `Failed to build iOS project.`,
+              `We ran "xcodebuild" command but it exited with error code ${code}.`,
+              `Consider building your app with XCode app to further debug this issue.`,
+            ].join(''),
+            errorOutput
+          )
+        );
+        return;
       }
-      return buildProcess.error ? reject(buildProcess.error) : resolve();
+      resolve(getProductName(buildOutput) || scheme);
     });
   });
+}
+
+function bootSimulator(selectedSimulator) {
+  const simulatorFullName = formattedDeviceName(selectedSimulator);
+  console.log(`Launching ${simulatorFullName}...`);
+  try {
+    child_process.spawnSync('xcrun', [
+      'instruments',
+      '-w',
+      selectedSimulator.udid,
+    ]);
+  } catch (_ignored) {
+    // instruments always fail with 255 because it expects more arguments,
+    // but we want it to only launch the simulator
+  }
+}
+
+function getBuildPath(configuration = 'Debug', appName, isDevice, scheme) {
+  let device;
+
+  if (isDevice) {
+    device = 'iphoneos';
+  } else if (appName.toLowerCase().includes('tvos')) {
+    device = 'appletvsimulator';
+  } else {
+    device = 'iphonesimulator';
+  }
+
+  return `build/${scheme}/Build/Products/${configuration}-${device}/${appName}.app`;
+}
+
+function getProductName(buildOutput) {
+  const productNameMatch = /export FULL_PRODUCT_NAME="?(.+).app"?$/m.exec(
+    buildOutput
+  );
+  return productNameMatch ? productNameMatch[1] : null;
+}
+
+function xcprettyAvailable() {
+  try {
+    child_process.execSync('xcpretty --version', {
+      stdio: [0, 'pipe', 'ignore'],
+    });
+  } catch (error) {
+    return false;
+  }
+  return true;
 }
 
 function matchingDevice(devices, deviceName) {
@@ -347,6 +388,7 @@ function matchingDevice(devices, deviceName) {
       return devices[i];
     }
   }
+  return null;
 }
 
 function matchingDeviceByUdid(devices, udid) {
@@ -355,6 +397,7 @@ function matchingDeviceByUdid(devices, udid) {
       return devices[i];
     }
   }
+  return null;
 }
 
 function formattedDeviceName(simulator) {
@@ -422,7 +465,7 @@ module.exports = {
       command: '--project-path [string]',
       description:
         'Path relative to project root where the Xcode project ' +
-        "(.xcodeproj) lives.",
+        '(.xcodeproj) lives.',
       default: 'ios',
     },
     {

--- a/packages/cli/src/util/errors.js
+++ b/packages/cli/src/util/errors.js
@@ -1,0 +1,15 @@
+/**
+ * @flow
+ */
+const chalk = require('chalk');
+
+class ProcessError extends Error {
+  constructor(msg: string, processError: string) {
+    super(`${chalk.red(msg)}\n\n${chalk.gray(processError)}`);
+    Error.captureStackTrace(this, ProcessError);
+  }
+}
+
+module.exports = {
+  ProcessError,
+};

--- a/packages/cli/src/util/logger.js
+++ b/packages/cli/src/util/logger.js
@@ -1,4 +1,6 @@
-// @flow
+/**
+ * @flow
+ */
 const chalk = require('chalk');
 
 const SEPARATOR = ', ';
@@ -23,32 +25,13 @@ const error = (...messages: Array<string>) => {
   );
 };
 
-const logError = (err: Error) => {
-  console.error(`${chalk.black.bgRed(' ERROR ')} ${chalk.red(err.message)} \n`);
-  if (err instanceof ProcessError) {
-    console.error(`${chalk.grey(err.processError)}`);
-  }
-};
-
 const debug = (...messages: Array<string>) => {
   console.log(`${chalk.black.bgWhite(' DEBUG ')} ${joinMessages(messages)}`);
 };
-
-class ProcessError extends Error {
-  constructor(msg: string, processError: string) {
-    super(msg);
-    this.processError = processError;
-    Error.captureStackTrace(this, ProcessError);
-  }
-
-  processError: string;
-}
 
 module.exports = {
   info,
   warn,
   error,
   debug,
-  logError,
-  ProcessError,
 };

--- a/packages/cli/src/util/logger.js
+++ b/packages/cli/src/util/logger.js
@@ -23,13 +23,32 @@ const error = (...messages: Array<string>) => {
   );
 };
 
+const logError = (err: Error) => {
+  console.error(`${chalk.black.bgRed(' ERROR ')} ${chalk.red(err.message)} \n`);
+  if (err instanceof ProcessError) {
+    console.error(`${chalk.grey(err.processError)}`);
+  }
+};
+
 const debug = (...messages: Array<string>) => {
   console.log(`${chalk.black.bgWhite(' DEBUG ')} ${joinMessages(messages)}`);
 };
+
+class ProcessError extends Error {
+  constructor(msg: string, processError: string) {
+    super(msg);
+    this.processError = processError;
+    Error.captureStackTrace(this, ProcessError);
+  }
+
+  processError: string;
+}
 
 module.exports = {
   info,
   warn,
   error,
   debug,
+  logError,
+  ProcessError,
 };


### PR DESCRIPTION
Fixes #107 

Summary:
---------

Bugs fixed:
- "CFBundleIdentifier" printed every time "run-ios" fails, shadowing the real cause for the problem
- "run-ios" running a previous/cached version of an app (usually when there was an error during build step that was ignored)

Changes made:
- Decided to turn Flow and ESLint and apply all the changes as I am working on it. I know the diff might be strange at first sight, but if you look closely, it's just cosmetics to satisfy various rules
- I also extracted some blocks to separate utilities for better readability
- I also removed a no longer needed check for CRNA which is deprecated (and IMO, is not needed)
- Converted few functions to "async" form for better readability
- Started capturing the "stderr" of "xcodebuild" and started relying on its error code in order to avoid going to next step when it fails
- Added a new type of error to differentiate from other errors and also be able to capture additional data. Logic and styling subject to change, encapsulated inside Logger.

Test Plan:
----------

Here's how the error messages look before/now:

While try to build a project with a wrong "schema" :

Before:
<img width="882" alt="screenshot 2019-01-31 at 18 07 43" src="https://user-images.githubusercontent.com/2464966/52071369-200a4c00-2583-11e9-8700-28766daae122.png">

After:
<img width="880" alt="screenshot 2019-01-31 at 18 05 23" src="https://user-images.githubusercontent.com/2464966/52071244-d91c5680-2582-11e9-83e7-e9e549a570cc.png">

While building a project that has a typo in "AppDelegate.m":

Before:
<img width="885" alt="screenshot 2019-01-31 at 18 08 19" src="https://user-images.githubusercontent.com/2464966/52071411-344e4900-2583-11e9-8613-96ddf6c68006.png">

After:
<img width="886" alt="screenshot 2019-01-31 at 18 06 36" src="https://user-images.githubusercontent.com/2464966/52071300-f6e9bb80-2582-11e9-9c9f-3a4b67318119.png">

You can try it out by running `run-ios` command on a broken project (typo, wrong configuration) or by passing a non-existing `schema`