### PR TITLE
fix: run-android not finding scripts to overwrite

### DIFF
--- a/packages/cli/src/runAndroid/runAndroid.js
+++ b/packages/cli/src/runAndroid/runAndroid.js
@@ -16,7 +16,6 @@ const { spawnSync, spawn, execFileSync } = require('child_process');
 const fs = require('fs');
 const isString = require('lodash/isString');
 const path = require('path');
-const findReactNativeScripts = require('../util/findReactNativeScripts');
 const isPackagerRunning = require('../util/isPackagerRunning');
 const adb = require('./adb');
 const runOnAllDevices = require('./runOnAllDevices');
@@ -34,20 +33,11 @@ function checkAndroid(root) {
  */
 function runAndroid(argv: Array<string>, config: ContextT, args: Object) {
   if (!checkAndroid(args.root)) {
-    const reactNativeScriptsPath = findReactNativeScripts();
-    if (reactNativeScriptsPath) {
-      spawnSync(
-        reactNativeScriptsPath,
-        ['android'].concat(process.argv.slice(1)),
-        { stdio: 'inherit' }
-      );
-    } else {
-      console.log(
-        chalk.red(
-          'Android project not found. Are you sure this is a React Native project?'
-        )
-      );
-    }
+    console.log(
+      chalk.red(
+        'Android project not found. Are you sure this is a React Native project?'
+      )
+    );
     return;
   }
 
@@ -210,7 +200,9 @@ function installAndLaunchOnDevice(
 }
 
 function startServerInNewWindow(port, terminal = process.env.REACT_TERMINAL) {
-  // set up OS-specific filenames and commands
+  /**
+   * Set up OS-specific filenames and commands
+   */
   const isWindows = /^win/.test(process.platform);
   const scriptFile = isWindows
     ? 'launchPackager.bat'
@@ -220,17 +212,24 @@ function startServerInNewWindow(port, terminal = process.env.REACT_TERMINAL) {
     ? `set RCT_METRO_PORT=${port}`
     : `export RCT_METRO_PORT=${port}`;
 
-  // set up the .packager.(env|bat) file to ensure the packager starts on the right port
+  /**
+   * Set up the `.packager.(env|bat)` file to ensure the packager starts on the right port.
+   */
   const launchPackagerScript = require.resolve(
     `react-native/scripts/${scriptFile}`
   );
 
-  // set up the launchpackager.(command|bat) file
+  /**
+   * Set up the `launchpackager.(command|bat)` file.
+   * It lives next to `.packager.(bat|env)`
+   */
   const scriptsDir = path.dirname(launchPackagerScript);
   const packagerEnvFile = path.join(scriptsDir, packagerEnvFilename);
   const procConfig: Object = { cwd: scriptsDir };
 
-  // ensure we overwrite file by passing the 'w' flag
+  /**
+   * Ensure we overwrite file by passing the `w` flag
+   */
   fs.writeFileSync(packagerEnvFile, portExportContent, {
     encoding: 'utf8',
     flag: 'w',

--- a/packages/cli/src/runAndroid/runAndroid.js
+++ b/packages/cli/src/runAndroid/runAndroid.js
@@ -215,28 +215,9 @@ function startServerInNewWindow(port, terminal = process.env.REACT_TERMINAL) {
   /**
    * Set up the `.packager.(env|bat)` file to ensure the packager starts on the right port.
    */
-  let launchPackagerScript;
-  try {
-    launchPackagerScript = require.resolve(
-      `react-native/scripts/${scriptFile}`
-    );
-  } catch (e) {
-    /**
-     * If the `react-native` package is missing, check if we are running from source.
-     *
-     * From `node_modules/@react-native-community/cli/build/run-android to `scripts/`
-     */
-    const possibleScriptLocation = path.resolve(
-      __dirname,
-      `../../../../../scripts/${scriptFile}`
-    );
-    if (!fs.existsSync(possibleScriptLocation)) {
-      throw new Error(
-        `Couldn't locate React Native files. To resolve this issue, try installing Node dependencies once again.`
-      );
-    }
-    launchPackagerScript = possibleScriptLocation;
-  }
+  const launchPackagerScript = require.resolve(
+    `react-native/scripts/${scriptFile}`
+  );
 
   /**
    * Set up the `launchpackager.(command|bat)` file.

--- a/packages/cli/src/runAndroid/runAndroid.js
+++ b/packages/cli/src/runAndroid/runAndroid.js
@@ -215,9 +215,28 @@ function startServerInNewWindow(port, terminal = process.env.REACT_TERMINAL) {
   /**
    * Set up the `.packager.(env|bat)` file to ensure the packager starts on the right port.
    */
-  const launchPackagerScript = require.resolve(
-    `react-native/scripts/${scriptFile}`
-  );
+  let launchPackagerScript;
+  try {
+    launchPackagerScript = require.resolve(
+      `react-native/scripts/${scriptFile}`
+    );
+  } catch (e) {
+    /**
+     * If the `react-native` package is missing, check if we are running from source.
+     *
+     * From `node_modules/@react-native-community/cli/build/run-android to `scripts/`
+     */
+    const possibleScriptLocation = path.resolve(
+      __dirname,
+      `../../../../../scripts/${scriptFile}`
+    );
+    if (!fs.existsSync(possibleScriptLocation)) {
+      throw new Error(
+        `Couldn't locate React Native files. To resolve this issue, try installing Node dependencies once again.`
+      );
+    }
+    launchPackagerScript = possibleScriptLocation;
+  }
 
   /**
    * Set up the `launchpackager.(command|bat)` file.

--- a/packages/cli/src/runAndroid/runAndroid.js
+++ b/packages/cli/src/runAndroid/runAndroid.js
@@ -220,19 +220,15 @@ function startServerInNewWindow(port, terminal = process.env.REACT_TERMINAL) {
     ? `set RCT_METRO_PORT=${port}`
     : `export RCT_METRO_PORT=${port}`;
 
-  // set up the launchpackager.(command|bat) file
-  const scriptsDir = path.resolve(__dirname, '..', '..', 'scripts');
-  const launchPackagerScript = path.resolve(scriptsDir, scriptFile);
-  const procConfig: Object = { cwd: scriptsDir };
-
   // set up the .packager.(env|bat) file to ensure the packager starts on the right port
-  const packagerEnvFile = path.join(
-    __dirname,
-    '..',
-    '..',
-    'scripts',
-    packagerEnvFilename
+  const launchPackagerScript = require.resolve(
+    `react-native/scripts/${scriptFile}`
   );
+
+  // set up the launchpackager.(command|bat) file
+  const scriptsDir = path.dirname(launchPackagerScript);
+  const packagerEnvFile = path.join(scriptsDir, packagerEnvFilename);
+  const procConfig: Object = { cwd: scriptsDir };
 
   // ensure we overwrite file by passing the 'w' flag
   fs.writeFileSync(packagerEnvFile, portExportContent, {


### PR DESCRIPTION
Fixes #126 

We need to change this approach, issue tracking in #140. 