### PR TITLE
chore: use ESM exports where appropriate

### DIFF
--- a/packages/cli/src/__mocks__/fs.js
+++ b/packages/cli/src/__mocks__/fs.js
@@ -7,6 +7,7 @@
 
 import path from 'path';
 import MemoryFS from 'metro-memory-fs';
+import util from 'util';
 
 let fs;
 
@@ -26,7 +27,7 @@ function mockDir(dirPath, desc) {
       continue; // eslint-disable-line no-continue
     }
     if (typeof ent !== 'object') {
-      throw new Error(require('util').format('invalid entity:', ent));
+      throw new Error(util.format('invalid entity:', ent));
     }
     if (ent.SYMLINK != null) {
       fs.symlinkSync(ent.SYMLINK, entPath);

--- a/packages/cli/src/bin.js
+++ b/packages/cli/src/bin.js
@@ -12,6 +12,7 @@
 import chalk from 'chalk';
 import isInstalledGlobally from './util/isInstalledGlobally';
 import logger from './util/logger';
+import cliEntry from '.';
 
 if (isInstalledGlobally()) {
   logger.error(
@@ -25,5 +26,5 @@ if (isInstalledGlobally()) {
   );
   process.exit(1);
 } else {
-  require('.').run();
+  cliEntry.run();
 }

--- a/packages/cli/src/bundle/__tests__/filterPlatformAssetScales-test.js
+++ b/packages/cli/src/bundle/__tests__/filterPlatformAssetScales-test.js
@@ -10,7 +10,7 @@
 
 jest.dontMock('../filterPlatformAssetScales').dontMock('../assetPathUtils');
 
-const filterPlatformAssetScales = require('../filterPlatformAssetScales');
+import filterPlatformAssetScales from '../filterPlatformAssetScales';
 
 describe('filterPlatformAssetScales', () => {
   it('removes everything but 2x and 3x for iOS', () => {

--- a/packages/cli/src/bundle/__tests__/filterPlatformAssetScales-test.js
+++ b/packages/cli/src/bundle/__tests__/filterPlatformAssetScales-test.js
@@ -8,9 +8,9 @@
  * @emails oncall+javascript_foundation
  */
 
-jest.dontMock('../filterPlatformAssetScales').dontMock('../assetPathUtils');
-
 import filterPlatformAssetScales from '../filterPlatformAssetScales';
+
+jest.dontMock('../filterPlatformAssetScales').dontMock('../assetPathUtils');
 
 describe('filterPlatformAssetScales', () => {
   it('removes everything but 2x and 3x for iOS', () => {

--- a/packages/cli/src/bundle/__tests__/getAssetDestPathAndroid-test.js
+++ b/packages/cli/src/bundle/__tests__/getAssetDestPathAndroid-test.js
@@ -11,7 +11,7 @@
 jest.dontMock('../getAssetDestPathAndroid').dontMock('../assetPathUtils');
 
 const path = require('path');
-const getAssetDestPathAndroid = require('../getAssetDestPathAndroid');
+import getAssetDestPathAndroid from '../getAssetDestPathAndroid';
 
 describe('getAssetDestPathAndroid', () => {
   it('should use the right destination folder', () => {

--- a/packages/cli/src/bundle/__tests__/getAssetDestPathAndroid-test.js
+++ b/packages/cli/src/bundle/__tests__/getAssetDestPathAndroid-test.js
@@ -8,10 +8,11 @@
  * @emails oncall+javascript_foundation
  */
 
+import getAssetDestPathAndroid from '../getAssetDestPathAndroid';
+
 jest.dontMock('../getAssetDestPathAndroid').dontMock('../assetPathUtils');
 
 const path = require('path');
-import getAssetDestPathAndroid from '../getAssetDestPathAndroid';
 
 describe('getAssetDestPathAndroid', () => {
   it('should use the right destination folder', () => {

--- a/packages/cli/src/bundle/__tests__/getAssetDestPathIOS-test.js
+++ b/packages/cli/src/bundle/__tests__/getAssetDestPathIOS-test.js
@@ -8,10 +8,11 @@
  * @emails oncall+javascript_foundation
  */
 
+import getAssetDestPathIOS from '../getAssetDestPathIOS';
+
 jest.dontMock('../getAssetDestPathIOS');
 
 const path = require('path');
-import getAssetDestPathIOS from '../getAssetDestPathIOS';
 
 describe('getAssetDestPathIOS', () => {
   it('should build correct path', () => {

--- a/packages/cli/src/bundle/__tests__/getAssetDestPathIOS-test.js
+++ b/packages/cli/src/bundle/__tests__/getAssetDestPathIOS-test.js
@@ -11,7 +11,7 @@
 jest.dontMock('../getAssetDestPathIOS');
 
 const path = require('path');
-const getAssetDestPathIOS = require('../getAssetDestPathIOS');
+import getAssetDestPathIOS from '../getAssetDestPathIOS';
 
 describe('getAssetDestPathIOS', () => {
   it('should build correct path', () => {

--- a/packages/cli/src/bundle/buildBundle.js
+++ b/packages/cli/src/bundle/buildBundle.js
@@ -65,4 +65,4 @@ async function buildBundle(
   }
 }
 
-module.exports = buildBundle;
+export default buildBundle;

--- a/packages/cli/src/bundle/bundle.js
+++ b/packages/cli/src/bundle/bundle.js
@@ -17,7 +17,7 @@ function bundleWithOutput(_, config, args, output) {
   return buildBundle(args, config, output);
 }
 
-module.exports = {
+export default {
   name: 'bundle',
   description: 'builds the javascript bundle for offline use',
   func: bundleWithOutput,

--- a/packages/cli/src/bundle/bundleCommandLineArgs.js
+++ b/packages/cli/src/bundle/bundleCommandLineArgs.js
@@ -28,7 +28,7 @@ export type CommandLineArgs = {
   verbose: boolean,
 };
 
-module.exports = [
+export default [
   {
     command: '--entry-file <path>',
     description:

--- a/packages/cli/src/bundle/filterPlatformAssetScales.js
+++ b/packages/cli/src/bundle/filterPlatformAssetScales.js
@@ -41,4 +41,4 @@ function filterPlatformAssetScales(
   return result;
 }
 
-module.exports = filterPlatformAssetScales;
+export default filterPlatformAssetScales;

--- a/packages/cli/src/bundle/getAssetDestPathAndroid.js
+++ b/packages/cli/src/bundle/getAssetDestPathAndroid.js
@@ -22,4 +22,4 @@ function getAssetDestPathAndroid(asset: PackagerAsset, scale: number): string {
   return path.join(androidFolder, `${fileName}.${asset.type}`);
 }
 
-module.exports = getAssetDestPathAndroid;
+export default getAssetDestPathAndroid;

--- a/packages/cli/src/bundle/getAssetDestPathIOS.js
+++ b/packages/cli/src/bundle/getAssetDestPathIOS.js
@@ -17,4 +17,4 @@ function getAssetDestPathIOS(asset: PackagerAsset, scale: number): string {
   return path.join(asset.httpServerLocation.substr(1), fileName);
 }
 
-module.exports = getAssetDestPathIOS;
+export default getAssetDestPathIOS;

--- a/packages/cli/src/bundle/ramBundle.js
+++ b/packages/cli/src/bundle/ramBundle.js
@@ -18,7 +18,7 @@ function ramBundle(argv, config, args) {
   return bundleWithOutput(argv, config, args, outputUnbundle);
 }
 
-module.exports = {
+export default {
   name: 'ram-bundle',
   description:
     'builds javascript as a "Random Access Module" bundle for offline use',

--- a/packages/cli/src/bundle/saveAssets.js
+++ b/packages/cli/src/bundle/saveAssets.js
@@ -82,4 +82,4 @@ function copy(src, dest, callback) {
   });
 }
 
-module.exports = saveAssets;
+export default saveAssets;

--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -191,7 +191,7 @@ async function setupAndRun() {
   }
 }
 
-module.exports = {
+export default {
   run,
   init,
 };

--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -18,7 +18,7 @@ import getCommands from './core/getCommands';
 import getLegacyConfig from './core/getLegacyConfig';
 import init from './init/init';
 import assertRequiredOptions from './util/assertRequiredOptions';
-import logger from './util/logger';
+import { error } from './util/logger';
 import pkg from '../package.json';
 
 commander.version(pkg.version);
@@ -26,7 +26,7 @@ commander.version(pkg.version);
 const defaultOptParser = val => val;
 
 const handleError = err => {
-  logger.error(err.message);
+  error(err.message);
   process.exit(1);
 };
 
@@ -70,7 +70,7 @@ function printHelpInformation() {
 }
 
 function printUnknownCommand(cmdName) {
-  logger.error(
+  error(
     [
       cmdName
         ? `Unrecognized command "${cmdName}".`
@@ -195,3 +195,5 @@ export default {
   run,
   init,
 };
+
+export { run, init };

--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -18,7 +18,7 @@ import getCommands from './core/getCommands';
 import getLegacyConfig from './core/getLegacyConfig';
 import init from './init/init';
 import assertRequiredOptions from './util/assertRequiredOptions';
-import { error } from './util/logger';
+import logger from './util/logger';
 import pkg from '../package.json';
 
 commander.version(pkg.version);
@@ -26,7 +26,7 @@ commander.version(pkg.version);
 const defaultOptParser = val => val;
 
 const handleError = err => {
-  error(err.message);
+  logger.error(err.message);
   process.exit(1);
 };
 
@@ -70,7 +70,7 @@ function printHelpInformation() {
 }
 
 function printUnknownCommand(cmdName) {
-  error(
+  logger.error(
     [
       cmdName
         ? `Unrecognized command "${cmdName}".`
@@ -196,4 +196,4 @@ export default {
   init,
 };
 
-export { run, init };
+// export { run, init };

--- a/packages/cli/src/core/__fixtures__/dependencies.js
+++ b/packages/cli/src/core/__fixtures__/dependencies.js
@@ -14,7 +14,7 @@ const fs = jest.requireActual('fs');
 
 const pjson = fs.readFileSync(path.join(__dirname, 'files', 'package.json'));
 
-module.exports = {
+export default {
   valid: {
     'package.json': pjson,
     android: android.valid,

--- a/packages/cli/src/core/__fixtures__/projects.js
+++ b/packages/cli/src/core/__fixtures__/projects.js
@@ -34,4 +34,4 @@ const withPods = {
   ios: ios.pod,
 };
 
-module.exports = { flat, nested, withExamples, withPods };
+export default { flat, nested, withExamples, withPods };

--- a/packages/cli/src/core/__fixtures__/projects.js
+++ b/packages/cli/src/core/__fixtures__/projects.js
@@ -36,4 +36,4 @@ const withPods = {
 
 export default { flat, nested, withExamples, withPods };
 
-export { flat, nested, withExamples, withPods };
+// export { flat, nested, withExamples, withPods };

--- a/packages/cli/src/core/__fixtures__/projects.js
+++ b/packages/cli/src/core/__fixtures__/projects.js
@@ -35,3 +35,5 @@ const withPods = {
 };
 
 export default { flat, nested, withExamples, withPods };
+
+export { flat, nested, withExamples, withPods };

--- a/packages/cli/src/core/__tests__/android/findAndroidAppFolder-test.js
+++ b/packages/cli/src/core/__tests__/android/findAndroidAppFolder-test.js
@@ -12,8 +12,8 @@ jest.mock('path');
 jest.mock('fs');
 
 const fs = require('fs');
-const findAndroidAppFolder = require('../../android/findAndroidAppFolder');
-const mocks = require('../../__fixtures__/android');
+import findAndroidAppFolder from '../../android/findAndroidAppFolder';
+import mocks from '../../__fixtures__/android';
 
 describe('android::findAndroidAppFolder', () => {
   beforeAll(() => {

--- a/packages/cli/src/core/__tests__/android/findAndroidAppFolder-test.js
+++ b/packages/cli/src/core/__tests__/android/findAndroidAppFolder-test.js
@@ -8,12 +8,13 @@
  * @emails oncall+javascript_foundation
  */
 
+import findAndroidAppFolder from '../../android/findAndroidAppFolder';
+import mocks from '../../__fixtures__/android';
+
 jest.mock('path');
 jest.mock('fs');
 
 const fs = require('fs');
-import findAndroidAppFolder from '../../android/findAndroidAppFolder';
-import mocks from '../../__fixtures__/android';
 
 describe('android::findAndroidAppFolder', () => {
   beforeAll(() => {

--- a/packages/cli/src/core/__tests__/android/findManifest-test.js
+++ b/packages/cli/src/core/__tests__/android/findManifest-test.js
@@ -12,8 +12,8 @@ jest.mock('path');
 jest.mock('fs');
 
 const fs = require('fs');
-const findManifest = require('../../android/findManifest');
-const mocks = require('../../__fixtures__/android');
+import findManifest from '../../android/findManifest';
+import mocks from '../../__fixtures__/android';
 
 describe('android::findManifest', () => {
   beforeAll(() => {

--- a/packages/cli/src/core/__tests__/android/findManifest-test.js
+++ b/packages/cli/src/core/__tests__/android/findManifest-test.js
@@ -8,12 +8,13 @@
  * @emails oncall+javascript_foundation
  */
 
+import findManifest from '../../android/findManifest';
+import mocks from '../../__fixtures__/android';
+
 jest.mock('path');
 jest.mock('fs');
 
 const fs = require('fs');
-import findManifest from '../../android/findManifest';
-import mocks from '../../__fixtures__/android';
 
 describe('android::findManifest', () => {
   beforeAll(() => {

--- a/packages/cli/src/core/__tests__/android/findPackageClassName-test.js
+++ b/packages/cli/src/core/__tests__/android/findPackageClassName-test.js
@@ -8,12 +8,13 @@
  * @emails oncall+javascript_foundation
  */
 
+import mocks from '../../__fixtures__/android';
+import findPackageClassName from '../../android/findPackageClassName';
+
 jest.mock('path');
 jest.mock('fs');
 
 const fs = require('fs');
-import mocks from '../../__fixtures__/android';
-import findPackageClassName from '../../android/findPackageClassName';
 
 ['posix', 'win32'].forEach(platform => {
   let root;

--- a/packages/cli/src/core/__tests__/android/findPackageClassName-test.js
+++ b/packages/cli/src/core/__tests__/android/findPackageClassName-test.js
@@ -12,8 +12,8 @@ jest.mock('path');
 jest.mock('fs');
 
 const fs = require('fs');
-const mocks = require('../../__fixtures__/android');
-const findPackageClassName = require('../../android/findPackageClassName');
+import mocks from '../../__fixtures__/android';
+import findPackageClassName from '../../android/findPackageClassName';
 
 ['posix', 'win32'].forEach(platform => {
   let root;

--- a/packages/cli/src/core/__tests__/android/getDependencyConfig-test.js
+++ b/packages/cli/src/core/__tests__/android/getDependencyConfig-test.js
@@ -14,7 +14,7 @@ jest.mock('fs');
 const fs = require('fs');
 
 const getDependencyConfig = require('../../android').dependencyConfig;
-const mocks = require('../../__fixtures__/android');
+import mocks from '../../__fixtures__/android';
 
 const userConfig = {};
 

--- a/packages/cli/src/core/__tests__/android/getDependencyConfig-test.js
+++ b/packages/cli/src/core/__tests__/android/getDependencyConfig-test.js
@@ -8,13 +8,14 @@
  * @emails oncall+javascript_foundation
  */
 
+import mocks from '../../__fixtures__/android';
+
 jest.mock('path');
 jest.mock('fs');
 
 const fs = require('fs');
 
 const getDependencyConfig = require('../../android').dependencyConfig;
-import mocks from '../../__fixtures__/android';
 
 const userConfig = {};
 

--- a/packages/cli/src/core/__tests__/android/getProjectConfig-test.js
+++ b/packages/cli/src/core/__tests__/android/getProjectConfig-test.js
@@ -8,13 +8,14 @@
  * @emails oncall+javascript_foundation
  */
 
+import mocks from '../../__fixtures__/android';
+
 jest.mock('path');
 jest.mock('fs');
 
 const fs = require('fs');
 
 const getProjectConfig = require('../../android').projectConfig;
-import mocks from '../../__fixtures__/android';
 
 describe('android::getProjectConfig', () => {
   beforeAll(() => {

--- a/packages/cli/src/core/__tests__/android/getProjectConfig-test.js
+++ b/packages/cli/src/core/__tests__/android/getProjectConfig-test.js
@@ -14,7 +14,7 @@ jest.mock('fs');
 const fs = require('fs');
 
 const getProjectConfig = require('../../android').projectConfig;
-const mocks = require('../../__fixtures__/android');
+import mocks from '../../__fixtures__/android';
 
 describe('android::getProjectConfig', () => {
   beforeAll(() => {

--- a/packages/cli/src/core/__tests__/android/readManifest-test.js
+++ b/packages/cli/src/core/__tests__/android/readManifest-test.js
@@ -12,9 +12,9 @@ jest.mock('path');
 jest.mock('fs');
 
 const fs = require('fs');
-const findManifest = require('../../android/findManifest');
-const readManifest = require('../../android/readManifest');
-const mocks = require('../../__fixtures__/android');
+import findManifest from '../../android/findManifest';
+import readManifest from '../../android/readManifest';
+import mocks from '../../__fixtures__/android';
 
 describe('android::readManifest', () => {
   beforeAll(() => {

--- a/packages/cli/src/core/__tests__/android/readManifest-test.js
+++ b/packages/cli/src/core/__tests__/android/readManifest-test.js
@@ -8,13 +8,14 @@
  * @emails oncall+javascript_foundation
  */
 
+import findManifest from '../../android/findManifest';
+import readManifest from '../../android/readManifest';
+import mocks from '../../__fixtures__/android';
+
 jest.mock('path');
 jest.mock('fs');
 
 const fs = require('fs');
-import findManifest from '../../android/findManifest';
-import readManifest from '../../android/readManifest';
-import mocks from '../../__fixtures__/android';
 
 describe('android::readManifest', () => {
   beforeAll(() => {

--- a/packages/cli/src/core/__tests__/findAssets-test.js
+++ b/packages/cli/src/core/__tests__/findAssets-test.js
@@ -8,13 +8,14 @@
  * @emails oncall+javascript_foundation
  */
 
+import dependencies from '../__fixtures__/dependencies';
+
 jest.mock('path');
 jest.mock('fs');
 
 const fs = require('fs');
 
 const { findAssets } = require('../getAssets');
-import dependencies from '../__fixtures__/dependencies';
 
 describe('findAssets', () => {
   beforeEach(() => {

--- a/packages/cli/src/core/__tests__/findAssets-test.js
+++ b/packages/cli/src/core/__tests__/findAssets-test.js
@@ -14,7 +14,7 @@ jest.mock('fs');
 const fs = require('fs');
 
 const { findAssets } = require('../getAssets');
-const dependencies = require('../__fixtures__/dependencies');
+import dependencies from '../__fixtures__/dependencies';
 
 describe('findAssets', () => {
   beforeEach(() => {

--- a/packages/cli/src/core/__tests__/findPlugins-test.js
+++ b/packages/cli/src/core/__tests__/findPlugins-test.js
@@ -9,7 +9,7 @@
  */
 
 const path = require('path');
-const findPlugins = require('../findPlugins');
+import findPlugins from '../findPlugins';
 
 const ROOT = path.join(__dirname, '..', '..');
 const pjsonPath = path.join(ROOT, './package.json');

--- a/packages/cli/src/core/__tests__/findPlugins-test.js
+++ b/packages/cli/src/core/__tests__/findPlugins-test.js
@@ -8,8 +8,9 @@
  * @emails oncall+javascript_foundation
  */
 
-const path = require('path');
 import findPlugins from '../findPlugins';
+
+const path = require('path');
 
 const ROOT = path.join(__dirname, '..', '..');
 const pjsonPath = path.join(ROOT, './package.json');

--- a/packages/cli/src/core/__tests__/ios/findPodfilePath-test.js
+++ b/packages/cli/src/core/__tests__/ios/findPodfilePath-test.js
@@ -12,9 +12,9 @@ jest.mock('path');
 jest.mock('fs');
 
 const fs = require('fs');
-const findPodfilePath = require('../../ios/findPodfilePath');
-const projects = require('../../__fixtures__/projects');
-const ios = require('../../__fixtures__/ios');
+import findPodfilePath from '../../ios/findPodfilePath';
+import projects from '../../__fixtures__/projects';
+import ios from '../../__fixtures__/ios';
 
 describe('ios::findPodfilePath', () => {
   it('returns null if there is no Podfile', () => {

--- a/packages/cli/src/core/__tests__/ios/findPodfilePath-test.js
+++ b/packages/cli/src/core/__tests__/ios/findPodfilePath-test.js
@@ -8,13 +8,14 @@
  * @emails oncall+javascript_foundation
  */
 
+import findPodfilePath from '../../ios/findPodfilePath';
+import projects from '../../__fixtures__/projects';
+import ios from '../../__fixtures__/ios';
+
 jest.mock('path');
 jest.mock('fs');
 
 const fs = require('fs');
-import findPodfilePath from '../../ios/findPodfilePath';
-import projects from '../../__fixtures__/projects';
-import ios from '../../__fixtures__/ios';
 
 describe('ios::findPodfilePath', () => {
   it('returns null if there is no Podfile', () => {

--- a/packages/cli/src/core/__tests__/ios/findPodspecName-test.js
+++ b/packages/cli/src/core/__tests__/ios/findPodspecName-test.js
@@ -12,9 +12,9 @@ jest.mock('path');
 jest.mock('fs');
 
 const fs = require('fs');
-const findPodspecName = require('../../ios/findPodspecName');
-const projects = require('../../__fixtures__/projects');
-const ios = require('../../__fixtures__/ios');
+import findPodspecName from '../../ios/findPodspecName';
+import projects from '../../__fixtures__/projects';
+import ios from '../../__fixtures__/ios';
 
 describe('ios::findPodspecName', () => {
   it('returns null if there is not podspec file', () => {

--- a/packages/cli/src/core/__tests__/ios/findPodspecName-test.js
+++ b/packages/cli/src/core/__tests__/ios/findPodspecName-test.js
@@ -8,13 +8,14 @@
  * @emails oncall+javascript_foundation
  */
 
+import findPodspecName from '../../ios/findPodspecName';
+import projects from '../../__fixtures__/projects';
+import ios from '../../__fixtures__/ios';
+
 jest.mock('path');
 jest.mock('fs');
 
 const fs = require('fs');
-import findPodspecName from '../../ios/findPodspecName';
-import projects from '../../__fixtures__/projects';
-import ios from '../../__fixtures__/ios';
 
 describe('ios::findPodspecName', () => {
   it('returns null if there is not podspec file', () => {

--- a/packages/cli/src/core/__tests__/ios/findProject-test.js
+++ b/packages/cli/src/core/__tests__/ios/findProject-test.js
@@ -8,13 +8,14 @@
  * @emails oncall+javascript_foundation
  */
 
+import findProject from '../../ios/findProject';
+import projects from '../../__fixtures__/projects';
+import ios from '../../__fixtures__/ios';
+
 jest.mock('path');
 jest.mock('fs');
 
 const fs = require('fs');
-import findProject from '../../ios/findProject';
-import projects from '../../__fixtures__/projects';
-import ios from '../../__fixtures__/ios';
 
 describe('ios::findProject', () => {
   it('returns path to xcodeproj if found', () => {

--- a/packages/cli/src/core/__tests__/ios/findProject-test.js
+++ b/packages/cli/src/core/__tests__/ios/findProject-test.js
@@ -12,9 +12,9 @@ jest.mock('path');
 jest.mock('fs');
 
 const fs = require('fs');
-const findProject = require('../../ios/findProject');
-const projects = require('../../__fixtures__/projects');
-const ios = require('../../__fixtures__/ios');
+import findProject from '../../ios/findProject';
+import projects from '../../__fixtures__/projects';
+import ios from '../../__fixtures__/ios';
 
 describe('ios::findProject', () => {
   it('returns path to xcodeproj if found', () => {

--- a/packages/cli/src/core/__tests__/ios/getProjectConfig-test.js
+++ b/packages/cli/src/core/__tests__/ios/getProjectConfig-test.js
@@ -8,13 +8,14 @@
  * @emails oncall+javascript_foundation
  */
 
+import projects from '../../__fixtures__/projects';
+
 jest.mock('path');
 jest.mock('fs');
 
 const fs = require('fs');
 
 const getProjectConfig = require('../../ios').projectConfig;
-import projects from '../../__fixtures__/projects';
 
 describe('ios::getProjectConfig', () => {
   const userConfig = {};

--- a/packages/cli/src/core/__tests__/ios/getProjectConfig-test.js
+++ b/packages/cli/src/core/__tests__/ios/getProjectConfig-test.js
@@ -14,7 +14,7 @@ jest.mock('fs');
 const fs = require('fs');
 
 const getProjectConfig = require('../../ios').projectConfig;
-const projects = require('../../__fixtures__/projects');
+import projects from '../../__fixtures__/projects';
 
 describe('ios::getProjectConfig', () => {
   const userConfig = {};

--- a/packages/cli/src/core/android/findAndroidAppFolder.js
+++ b/packages/cli/src/core/android/findAndroidAppFolder.js
@@ -14,7 +14,7 @@ import path from 'path';
  * @param  {String} folder Folder to seek in
  * @return {String}
  */
-module.exports = function findAndroidAppFolder(folder) {
+export default function findAndroidAppFolder(folder) {
   const flat = 'android';
   const nested = path.join('android', 'app');
 
@@ -27,4 +27,4 @@ module.exports = function findAndroidAppFolder(folder) {
   }
 
   return null;
-};
+}

--- a/packages/cli/src/core/android/findManifest.js
+++ b/packages/cli/src/core/android/findManifest.js
@@ -16,11 +16,11 @@ import path from 'path';
  * @param {String} folder Name of the folder where to seek
  * @return {String}
  */
-module.exports = function findManifest(folder) {
+export default function findManifest(folder) {
   const manifestPath = glob.sync(path.join('**', 'AndroidManifest.xml'), {
     cwd: folder,
     ignore: ['node_modules/**', '**/build/**', 'Examples/**', 'examples/**'],
   })[0];
 
   return manifestPath ? path.join(folder, manifestPath) : null;
-};
+}

--- a/packages/cli/src/core/android/findPackageClassName.js
+++ b/packages/cli/src/core/android/findPackageClassName.js
@@ -17,7 +17,7 @@ import path from 'path';
  *
  * @param {String} folder Folder to find java/kt files
  */
-module.exports = function getPackageClassName(folder) {
+export default function getPackageClassName(folder) {
   const files = glob.sync('**/+(*.java|*.kt)', { cwd: folder });
 
   const packages = files
@@ -26,4 +26,4 @@ module.exports = function getPackageClassName(folder) {
     .filter(match => match);
 
   return packages.length ? packages[0][1] : null;
-};
+}

--- a/packages/cli/src/core/android/index.js
+++ b/packages/cli/src/core/android/index.js
@@ -12,6 +12,9 @@ import findAndroidAppFolder from './findAndroidAppFolder';
 import findManifest from './findManifest';
 import findPackageClassName from './findPackageClassName';
 import readManifest from './readManifest';
+import linkConfigAndroid from '../../link/android';
+
+export const linkConfig = linkConfigAndroid;
 
 const getPackageName = manifest => manifest.attr.package;
 
@@ -19,7 +22,7 @@ const getPackageName = manifest => manifest.attr.package;
  * Gets android project config by analyzing given folder and taking some
  * defaults specified by user into consideration
  */
-exports.projectConfig = function projectConfigAndroid(folder, userConfig = {}) {
+export function projectConfig(folder, userConfig = {}) {
   const src = userConfig.sourceDir || findAndroidAppFolder(folder);
 
   if (!src) {
@@ -85,16 +88,13 @@ exports.projectConfig = function projectConfigAndroid(folder, userConfig = {}) {
     assetsPath,
     mainFilePath,
   };
-};
+}
 
 /**
  * Same as projectConfigAndroid except it returns
  * different config that applies to packages only
  */
-exports.dependencyConfig = function dependencyConfigAndroid(
-  folder,
-  userConfig = {}
-) {
+export function dependencyConfig(folder, userConfig = {}) {
   const src = userConfig.sourceDir || findAndroidAppFolder(folder);
 
   if (!src) {
@@ -129,6 +129,4 @@ exports.dependencyConfig = function dependencyConfigAndroid(
     userConfig.packageInstance || `new ${packageClassName}()`;
 
   return { sourceDir, folder, manifest, packageImportPath, packageInstance };
-};
-
-exports.linkConfig = require('../../link/android');
+}

--- a/packages/cli/src/core/android/readManifest.js
+++ b/packages/cli/src/core/android/readManifest.js
@@ -14,6 +14,6 @@ import xml from 'xmldoc';
  * @param  {String} manifestPath
  * @return {XMLDocument} Parsed manifest's content
  */
-module.exports = function readManifest(manifestPath) {
+export default function readManifest(manifestPath) {
   return new xml.XmlDocument(fs.readFileSync(manifestPath, 'utf8'));
-};
+}

--- a/packages/cli/src/core/findPlugins.js
+++ b/packages/cli/src/core/findPlugins.js
@@ -113,7 +113,7 @@ const findPluginsInFolder = folder => {
  * Find plugins in package.json of the given folder
  * @param {String} folder Path to the folder to get the package.json from
  */
-module.exports = function findPlugins(folder: string) {
+export default function findPlugins(folder: string) {
   const plugin = findPluginsInFolder(folder);
   return {
     commands: uniq(flatten(plugin.commands)),
@@ -125,4 +125,4 @@ module.exports = function findPlugins(folder: string) {
       ),
     },
   };
-};
+}

--- a/packages/cli/src/core/getAssets.js
+++ b/packages/cli/src/core/getAssets.js
@@ -28,9 +28,9 @@ function findAssets(folder, assets) {
 /**
  * Returns a project configuration in a given folder
  */
-module.exports = function getAssets(root: string) {
+export default function getAssets(root: string) {
   const config = getPackageConfiguration(root);
   return findAssets(root, config.assets);
-};
+}
 
 module.exports.findAssets = findAssets;

--- a/packages/cli/src/core/getAssets.js
+++ b/packages/cli/src/core/getAssets.js
@@ -15,7 +15,7 @@ const findAssetsInFolder = folder =>
  *
  * It returns an array of absolute paths to files found.
  */
-function findAssets(folder, assets) {
+export function findAssets(folder: string, assets?: string[]) {
   return (assets || [])
     .map(asset => path.join(folder, asset))
     .reduce(
@@ -32,5 +32,3 @@ export default function getAssets(root: string) {
   const config = getPackageConfiguration(root);
   return findAssets(root, config.assets);
 }
-
-module.exports.findAssets = findAssets;

--- a/packages/cli/src/core/getCommands.js
+++ b/packages/cli/src/core/getCommands.js
@@ -30,7 +30,7 @@ import info from '../info/info';
  * List of built-in commands
  */
 
-const loadLocalCommands = (): Array<LocalCommandT> => [
+const loadLocalCommands: Array<LocalCommandT> = [
   server,
   runIOS,
   runAndroid,
@@ -100,7 +100,7 @@ const loadProjectCommands = (root: string): Array<ProjectCommandT> => {
  * Loads all the commands inside a given `root` folder
  */
 export default (root: string): Array<CommandT> => [
-  ...loadLocalCommands(),
+  ...loadLocalCommands,
   {
     name: 'init',
     func: () => {

--- a/packages/cli/src/core/getCommands.js
+++ b/packages/cli/src/core/getCommands.js
@@ -3,31 +3,50 @@
  */
 
 import path from 'path';
-import type { CommandT, ProjectCommandT, LocalCommandT } from './types.flow';
 
 import findPlugins from './findPlugins';
 import logger from '../util/logger';
 
+import type { CommandT, ProjectCommandT, LocalCommandT } from './types.flow';
+
+import server from '../server/server';
+import runIOS from '../runIOS/runIOS';
+import runAndroid from '../runAndroid/runAndroid';
+import library from '../library/library';
+import bundle from '../bundle/bundle';
+import ramBundle from '../bundle/ramBundle';
+import eject from '../eject/eject';
+import link from '../link/link';
+import unlink from '../link/unlink';
+import install from '../install/install';
+import uninstall from '../install/uninstall';
+import upgrade from '../upgrade/upgrade';
+import logAndroid from '../logAndroid/logAndroid';
+import logIOS from '../logIOS/logIOS';
+import dependencies from '../dependencies/dependencies';
+import info from '../info/info';
+
 /**
  * List of built-in commands
  */
+
 const loadLocalCommands = (): Array<LocalCommandT> => [
-  require('../server/server'),
-  require('../runIOS/runIOS'),
-  require('../runAndroid/runAndroid'),
-  require('../library/library'),
-  require('../bundle/bundle'),
-  require('../bundle/ramBundle'),
-  require('../eject/eject'),
-  require('../link/link'),
-  require('../link/unlink'),
-  require('../install/install'),
-  require('../install/uninstall'),
-  require('../upgrade/upgrade'),
-  require('../logAndroid/logAndroid'),
-  require('../logIOS/logIOS'),
-  require('../dependencies/dependencies'),
-  require('../info/info'),
+  server,
+  runIOS,
+  runAndroid,
+  library,
+  bundle,
+  ramBundle,
+  eject,
+  link,
+  unlink,
+  install,
+  uninstall,
+  upgrade,
+  logAndroid,
+  logIOS,
+  dependencies,
+  info,
 ];
 
 /**

--- a/packages/cli/src/core/getCommands.js
+++ b/packages/cli/src/core/getCommands.js
@@ -80,7 +80,7 @@ const loadProjectCommands = (root: string): Array<ProjectCommandT> => {
 /**
  * Loads all the commands inside a given `root` folder
  */
-module.exports = (root: string): Array<CommandT> => [
+export default (root: string): Array<CommandT> => [
   ...loadLocalCommands(),
   {
     name: 'init',

--- a/packages/cli/src/core/getHooks.js
+++ b/packages/cli/src/core/getHooks.js
@@ -5,8 +5,9 @@
 import { spawn } from 'child_process';
 import getPackageConfiguration from './getPackageConfiguration';
 
-function makeCommand(command) {
-  return cb => {
+export function makeCommand(command: string) {
+  // eslint-disable-next-line flowtype/no-weak-types
+  return (cb: Function) => {
     if (!cb) {
       throw new Error(
         `You missed a callback function for the ${command} command`
@@ -42,5 +43,3 @@ export default function getHooks(root: string) {
 
   return acc;
 }
-
-module.exports.makeCommand = makeCommand;

--- a/packages/cli/src/core/getHooks.js
+++ b/packages/cli/src/core/getHooks.js
@@ -31,7 +31,7 @@ function makeCommand(command) {
   };
 }
 
-module.exports = function getHooks(root: string) {
+export default function getHooks(root: string) {
   const commands = getPackageConfiguration(root).commands || {};
 
   const acc = {};
@@ -41,6 +41,6 @@ module.exports = function getHooks(root: string) {
   });
 
   return acc;
-};
+}
 
 module.exports.makeCommand = makeCommand;

--- a/packages/cli/src/core/getLegacyConfig.js
+++ b/packages/cli/src/core/getLegacyConfig.js
@@ -19,7 +19,7 @@ const generateDeprecationMessage = api =>
  *
  * This file will be removed from the next version.
  */
-module.exports = (root: string) => ({
+export default (root: string) => ({
   getPlatformConfig: util.deprecate(
     () => getPlatforms(root),
     generateDeprecationMessage('getPlatformConfig()')

--- a/packages/cli/src/core/getPackageConfiguration.js
+++ b/packages/cli/src/core/getPackageConfiguration.js
@@ -7,9 +7,9 @@ import type { PackageConfigurationT } from './types.flow';
 /**
  * Returns configuration of the CLI from `package.json`.
  */
-module.exports = function getPackageConfiguration(
+export default function getPackageConfiguration(
   folder: string
 ): PackageConfigurationT {
   // $FlowFixMe: Non-literal require
   return require(path.join(folder, './package.json')).rnpm || {};
-};
+}

--- a/packages/cli/src/core/getParams.js
+++ b/packages/cli/src/core/getParams.js
@@ -4,7 +4,7 @@
 
 import getPackageConfiguration from './getPackageConfiguration';
 
-module.exports = function getParams(root: string) {
+export default function getParams(root: string) {
   const config = getPackageConfiguration(root);
   return config.params || [];
-};
+}

--- a/packages/cli/src/core/getPlatforms.js
+++ b/packages/cli/src/core/getPlatforms.js
@@ -21,7 +21,7 @@ const builtInPlatforms = {
 /**
  * Returns an object with available platforms
  */
-module.exports = function getPlatforms(root: string): PlatformsT {
+export default function getPlatforms(root: string): PlatformsT {
   const plugins = findPlugins(root);
 
   /**
@@ -44,4 +44,4 @@ module.exports = function getPlatforms(root: string): PlatformsT {
     ...builtInPlatforms,
     ...projectPlatforms,
   };
-};
+}

--- a/packages/cli/src/core/ios/findPodfilePath.js
+++ b/packages/cli/src/core/ios/findPodfilePath.js
@@ -10,9 +10,9 @@
 import fs from 'fs';
 import path from 'path';
 
-module.exports = function findPodfilePath(projectFolder) {
+export default function findPodfilePath(projectFolder) {
   const podFilePath = path.join(projectFolder, '..', 'Podfile');
   const podFileExists = fs.existsSync(podFilePath);
 
   return podFileExists ? podFilePath : null;
-};
+}

--- a/packages/cli/src/core/ios/findPodspecName.js
+++ b/packages/cli/src/core/ios/findPodspecName.js
@@ -10,7 +10,7 @@
 import glob from 'glob';
 import path from 'path';
 
-module.exports = function findPodspecName(folder) {
+export default function findPodspecName(folder) {
   const podspecs = glob.sync('*.podspec', { cwd: folder });
   let podspecFile = null;
   if (podspecs.length === 0) {
@@ -30,4 +30,4 @@ module.exports = function findPodspecName(folder) {
   }
 
   return podspecFile.replace('.podspec', '');
-};
+}

--- a/packages/cli/src/core/ios/findProject.js
+++ b/packages/cli/src/core/ios/findProject.js
@@ -38,7 +38,7 @@ const GLOB_EXCLUDE_PATTERN = ['**/@(Pods|node_modules)/**'];
  *
  * Note: `./ios/*.xcodeproj` are returned regardless of the name
  */
-module.exports = function findProject(folder) {
+export default function findProject(folder) {
   const projects = glob
     .sync(GLOB_PATTERN, {
       cwd: folder,
@@ -55,4 +55,4 @@ module.exports = function findProject(folder) {
   }
 
   return projects[0];
-};
+}

--- a/packages/cli/src/core/ios/index.js
+++ b/packages/cli/src/core/ios/index.js
@@ -11,6 +11,9 @@ import path from 'path';
 import findProject from './findProject';
 import findPodfilePath from './findPodfilePath';
 import findPodspecName from './findPodspecName';
+import linkConfigIos from '../../link/ios';
+
+export const linkConfig = linkConfigIos;
 
 /**
  * For libraries specified without an extension, add '.tbd' for those that
@@ -28,7 +31,7 @@ const mapSharedLibaries = libraries =>
  * Returns project config by analyzing given folder and applying some user defaults
  * when constructing final object
  */
-exports.projectConfig = function projectConfigIOS(folder, userConfig) {
+export function projectConfig(folder, userConfig) {
   const project = userConfig.project || findProject(folder);
 
   /**
@@ -52,8 +55,6 @@ exports.projectConfig = function projectConfigIOS(folder, userConfig) {
     sharedLibraries: mapSharedLibaries(userConfig.sharedLibraries || []),
     plist: userConfig.plist || [],
   };
-};
+}
 
-exports.dependencyConfig = exports.projectConfig;
-
-exports.linkConfig = require('../../link/ios');
+export const dependencyConfig = projectConfig;

--- a/packages/cli/src/dependencies/dependencies.js
+++ b/packages/cli/src/dependencies/dependencies.js
@@ -64,7 +64,7 @@ async function dependencies(argv, configPromise, args, packagerInstance) {
     : Promise.resolve();
 }
 
-module.exports = {
+export default {
   name: 'dependencies',
   description: 'lists dependencies',
   func: util.deprecate(

--- a/packages/cli/src/eject/eject.js
+++ b/packages/cli/src/eject/eject.js
@@ -106,7 +106,7 @@ function eject() {
   }
 }
 
-module.exports = {
+export default {
   name: 'eject',
   description: 'Re-create the iOS and Android folders and native code',
   func: eject,

--- a/packages/cli/src/generator/copyProjectTemplateAndReplace.js
+++ b/packages/cli/src/generator/copyProjectTemplateAndReplace.js
@@ -167,4 +167,4 @@ function upgradeFileContentChangedCallback(
   );
 }
 
-module.exports = copyProjectTemplateAndReplace;
+export default copyProjectTemplateAndReplace;

--- a/packages/cli/src/generator/printRunInstructions.js
+++ b/packages/cli/src/generator/printRunInstructions.js
@@ -35,4 +35,4 @@ function printRunInstructions(projectDir, projectName) {
     react-native run-android`);
 }
 
-module.exports = printRunInstructions;
+export default printRunInstructions;

--- a/packages/cli/src/generator/promptSync.js
+++ b/packages/cli/src/generator/promptSync.js
@@ -138,4 +138,4 @@ function create() {
   }
 }
 
-module.exports = create;
+export default create;

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -17,4 +17,4 @@ if (require.main === module) {
   cli.run();
 }
 
-module.exports = cli;
+export default cli;

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -17,4 +17,4 @@ if (require.main === module) {
   cli.run();
 }
 
-export default cli;
+module.exports = cli;

--- a/packages/cli/src/info/info.js
+++ b/packages/cli/src/info/info.js
@@ -43,7 +43,7 @@ const info = function getInfo(argv, ctx, options) {
   }
 };
 
-module.exports = {
+export default {
   name: 'info',
   description: 'Get relevant version info about OS, toolchain and libraries',
   options: [

--- a/packages/cli/src/init/init.js
+++ b/packages/cli/src/init/init.js
@@ -15,7 +15,7 @@ import printRunInstructions from '../generator/printRunInstructions';
 import { createProjectFromTemplate } from '../generator/templates';
 import yarn from '../util/yarn';
 import PackageManager from '../util/PackageManager';
-import { error, info } from '../util/logger';
+import logger from '../util/logger';
 
 /**
  * Creates the template for a React Native project given the provided
@@ -33,14 +33,14 @@ function init(projectDir, argsOrName) {
 
   // args array is e.g. ['AwesomeApp', '--verbose', '--template', 'navigation']
   if (!args || args.length === 0) {
-    error('react-native init requires a project name.');
+    logger.error('react-native init requires a project name.');
     return;
   }
 
   const newProjectName = args[0];
   const options = minimist(args);
 
-  info(`Setting up new React Native app in ${projectDir}`);
+  logger.info(`Setting up new React Native app in ${projectDir}`);
   generateProject(projectDir, newProjectName, options);
 }
 
@@ -54,7 +54,7 @@ function generateProject(destinationRoot, newProjectName, options) {
   const reactNativePackageJson = require('react-native/package.json');
   const { peerDependencies } = reactNativePackageJson;
   if (!peerDependencies) {
-    error(
+    logger.error(
       "Missing React peer dependency in React Native's package.json. Aborting."
     );
     return;
@@ -62,7 +62,7 @@ function generateProject(destinationRoot, newProjectName, options) {
 
   const reactVersion = peerDependencies.react;
   if (!reactVersion) {
-    error(
+    logger.error(
       "Missing React peer dependency in React Native's package.json. Aborting."
     );
     return;
@@ -86,10 +86,10 @@ function generateProject(destinationRoot, newProjectName, options) {
     yarnVersion
   );
 
-  info('Adding required dependencies');
+  logger.info('Adding required dependencies');
   packageManager.install([`react@${reactVersion}`]);
 
-  info('Adding required dev dependencies');
+  logger.info('Adding required dev dependencies');
   packageManager.installDev([
     '@babel/core',
     '@babel/runtime',

--- a/packages/cli/src/init/init.js
+++ b/packages/cli/src/init/init.js
@@ -14,8 +14,8 @@ import process from 'process';
 import printRunInstructions from '../generator/printRunInstructions';
 import { createProjectFromTemplate } from '../generator/templates';
 import yarn from '../util/yarn';
-import logger from '../util/logger';
 import PackageManager from '../util/PackageManager';
+import { error, info } from '../util/logger';
 
 /**
  * Creates the template for a React Native project given the provided
@@ -33,14 +33,14 @@ function init(projectDir, argsOrName) {
 
   // args array is e.g. ['AwesomeApp', '--verbose', '--template', 'navigation']
   if (!args || args.length === 0) {
-    logger.error('react-native init requires a project name.');
+    error('react-native init requires a project name.');
     return;
   }
 
   const newProjectName = args[0];
   const options = minimist(args);
 
-  logger.info(`Setting up new React Native app in ${projectDir}`);
+  info(`Setting up new React Native app in ${projectDir}`);
   generateProject(projectDir, newProjectName, options);
 }
 
@@ -54,7 +54,7 @@ function generateProject(destinationRoot, newProjectName, options) {
   const reactNativePackageJson = require('react-native/package.json');
   const { peerDependencies } = reactNativePackageJson;
   if (!peerDependencies) {
-    logger.error(
+    error(
       "Missing React peer dependency in React Native's package.json. Aborting."
     );
     return;
@@ -62,7 +62,7 @@ function generateProject(destinationRoot, newProjectName, options) {
 
   const reactVersion = peerDependencies.react;
   if (!reactVersion) {
-    logger.error(
+    error(
       "Missing React peer dependency in React Native's package.json. Aborting."
     );
     return;
@@ -86,10 +86,10 @@ function generateProject(destinationRoot, newProjectName, options) {
     yarnVersion
   );
 
-  logger.info('Adding required dependencies');
+  info('Adding required dependencies');
   packageManager.install([`react@${reactVersion}`]);
 
-  logger.info('Adding required dev dependencies');
+  info('Adding required dev dependencies');
   packageManager.installDev([
     '@babel/core',
     '@babel/runtime',

--- a/packages/cli/src/init/init.js
+++ b/packages/cli/src/init/init.js
@@ -122,4 +122,4 @@ function addJestToPackageJson(destinationRoot) {
   );
 }
 
-module.exports = init;
+export default init;

--- a/packages/cli/src/install/install.js
+++ b/packages/cli/src/install/install.js
@@ -34,7 +34,7 @@ function install(args, ctx) {
   logger.info(`Module ${name} has been successfully installed & linked`);
 }
 
-module.exports = {
+export default {
   func: install,
   description: 'install and link native dependencies',
   name: 'install <packageName>',

--- a/packages/cli/src/install/uninstall.js
+++ b/packages/cli/src/install/uninstall.js
@@ -34,7 +34,7 @@ function uninstall(args, ctx) {
   logger.info(`Module ${name} has been successfully uninstalled & unlinked`);
 }
 
-module.exports = {
+export default {
   func: uninstall,
   description: 'uninstall and unlink native dependencies',
   name: 'uninstall <packageName>',

--- a/packages/cli/src/library/library.js
+++ b/packages/cli/src/library/library.js
@@ -64,7 +64,7 @@ Now it needs to be linked in Xcode:
 https://facebook.github.io/react-native/docs/linking-libraries-ios.html#content`);
 }
 
-module.exports = {
+export default {
   name: 'new-library',
   func: library,
   description: 'generates a native library bridge',

--- a/packages/cli/src/link/__tests__/android/applyPatch-test.js
+++ b/packages/cli/src/link/__tests__/android/applyPatch-test.js
@@ -7,7 +7,7 @@
 
 /* eslint-disable no-template-curly-in-string */
 
-const applyParams = require('../../android/patches/applyParams');
+import applyParams from '../../android/patches/applyParams';
 
 describe('applyParams', () => {
   it('apply params to the string', () => {

--- a/packages/cli/src/link/__tests__/android/isInstalled-test.js
+++ b/packages/cli/src/link/__tests__/android/isInstalled-test.js
@@ -9,7 +9,7 @@
  */
 
 const path = require('path');
-const isInstalled = require('../../android/isInstalled');
+import isInstalled from '../../android/isInstalled';
 
 const projectConfig = {
   buildGradlePath: path.join(

--- a/packages/cli/src/link/__tests__/android/isInstalled-test.js
+++ b/packages/cli/src/link/__tests__/android/isInstalled-test.js
@@ -8,8 +8,9 @@
  * @emails oncall+javascript_foundation
  */
 
-const path = require('path');
 import isInstalled from '../../android/isInstalled';
+
+const path = require('path');
 
 const projectConfig = {
   buildGradlePath: path.join(

--- a/packages/cli/src/link/__tests__/android/makeBuildPatch-test.js
+++ b/packages/cli/src/link/__tests__/android/makeBuildPatch-test.js
@@ -8,8 +8,8 @@
  * @emails oncall+javascript_foundation
  */
 
-const makeBuildPatch = require('../../android/patches/makeBuildPatch');
-const normalizeProjectName = require('../../android/patches/normalizeProjectName');
+import makeBuildPatch from '../../android/patches/makeBuildPatch';
+import normalizeProjectName from '../../android/patches/normalizeProjectName';
 
 const name = 'test';
 const scopedName = '@scoped/test';

--- a/packages/cli/src/link/__tests__/android/makeImportPatch-test.js
+++ b/packages/cli/src/link/__tests__/android/makeImportPatch-test.js
@@ -8,7 +8,7 @@
  * @emails oncall+javascript_foundation
  */
 
-const makeImportPatch = require('../../android/patches/makeImportPatch');
+import makeImportPatch from '../../android/patches/makeImportPatch';
 
 const packageImportPath = 'import some.example.project';
 

--- a/packages/cli/src/link/__tests__/android/makePackagePatch-test.js
+++ b/packages/cli/src/link/__tests__/android/makePackagePatch-test.js
@@ -7,8 +7,8 @@
 
 /* eslint-disable no-template-curly-in-string */
 
-const makePackagePatch = require('../../android/patches/makePackagePatch');
-const applyParams = require('../../android/patches/applyParams');
+import makePackagePatch from '../../android/patches/makePackagePatch';
+import applyParams from '../../android/patches/applyParams';
 
 const packageInstance = "new SomeLibrary(${foo}, ${bar}, 'something')";
 const name = 'some-library';

--- a/packages/cli/src/link/__tests__/android/makeSettingsPatch-test.js
+++ b/packages/cli/src/link/__tests__/android/makeSettingsPatch-test.js
@@ -50,7 +50,8 @@ project(':test').projectDir = new File(rootProject.projectDir, '../node_modules/
       return path;
     });
     // eslint-disable-next-line no-shadow
-    const makeSettingsPatch = require('../../android/patches/makeSettingsPatch').default;
+    const makeSettingsPatch = require('../../android/patches/makeSettingsPatch')
+      .default;
     const projectConfigWindows = {
       sourceDir: 'C:\\home\\project\\android\\app',
       settingsGradlePath: 'C:\\home\\project\\android\\settings.gradle',

--- a/packages/cli/src/link/__tests__/android/makeSettingsPatch-test.js
+++ b/packages/cli/src/link/__tests__/android/makeSettingsPatch-test.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-const makeSettingsPatch = require('../../android/patches/makeSettingsPatch');
+import makeSettingsPatch from '../../android/patches/makeSettingsPatch';
 
 const projectConfig = {
   sourceDir: '/home/project/android/app',
@@ -50,7 +50,7 @@ project(':test').projectDir = new File(rootProject.projectDir, '../node_modules/
       return path;
     });
     // eslint-disable-next-line no-shadow
-    const makeSettingsPatch = require('../../android/patches/makeSettingsPatch');
+    const makeSettingsPatch = require('../../android/patches/makeSettingsPatch').default;
     const projectConfigWindows = {
       sourceDir: 'C:\\home\\project\\android\\app',
       settingsGradlePath: 'C:\\home\\project\\android\\settings.gradle',

--- a/packages/cli/src/link/__tests__/android/makeStringsPatch-test.js
+++ b/packages/cli/src/link/__tests__/android/makeStringsPatch-test.js
@@ -8,7 +8,7 @@
  * @emails oncall+javascript_foundation
  */
 
-const makeStringsPatch = require('../../android/patches/makeStringsPatch');
+import makeStringsPatch from '../../android/patches/makeStringsPatch';
 
 describe('makeStringsPatch', () => {
   it('should export a patch with <string> element', () => {

--- a/packages/cli/src/link/__tests__/android/normalizeProjectName-test.js
+++ b/packages/cli/src/link/__tests__/android/normalizeProjectName-test.js
@@ -8,7 +8,7 @@
  * @emails oncall+javascript_foundation
  */
 
-const normalizeProjectName = require('../../android/patches/normalizeProjectName');
+import normalizeProjectName from '../../android/patches/normalizeProjectName';
 
 const name = 'test';
 const scopedName = '@scoped/test';

--- a/packages/cli/src/link/__tests__/getDependencyConfig-test.js
+++ b/packages/cli/src/link/__tests__/getDependencyConfig-test.js
@@ -24,7 +24,7 @@ jest.setMock('../../core/getPackageConfiguration', folder => {
   return {};
 });
 
-const getDependencyConfig = require('../getDependencyConfig');
+const getDependencyConfig = require('../getDependencyConfig').default;
 
 describe('getDependencyConfig', () => {
   it("should return an array of dependencies' config", () => {

--- a/packages/cli/src/link/__tests__/getProjectDependencies-test.js
+++ b/packages/cli/src/link/__tests__/getProjectDependencies-test.js
@@ -9,8 +9,9 @@
  * @format
  */
 
-const path = require('path');
 import getProjectDependencies from '../getProjectDependencies';
+
+const path = require('path');
 
 const CWD = path.resolve(__dirname, '../../');
 

--- a/packages/cli/src/link/__tests__/getProjectDependencies-test.js
+++ b/packages/cli/src/link/__tests__/getProjectDependencies-test.js
@@ -10,7 +10,7 @@
  */
 
 const path = require('path');
-const getProjectDependencies = require('../getProjectDependencies');
+import getProjectDependencies from '../getProjectDependencies';
 
 const CWD = path.resolve(__dirname, '../../');
 

--- a/packages/cli/src/link/__tests__/groupFilesByType-test.js
+++ b/packages/cli/src/link/__tests__/groupFilesByType-test.js
@@ -8,7 +8,7 @@
  * @emails oncall+javascript_foundation
  */
 
-const groupFilesByType = require('../groupFilesByType');
+import groupFilesByType from '../groupFilesByType';
 
 describe('groupFilesByType', () => {
   it('should group files by its type', () => {

--- a/packages/cli/src/link/__tests__/ios/addFileToProject-test.js
+++ b/packages/cli/src/link/__tests__/ios/addFileToProject-test.js
@@ -11,7 +11,7 @@
 const xcode = require('xcode');
 const path = require('path');
 const _ = require('lodash');
-const addFileToProject = require('../../ios/addFileToProject');
+import addFileToProject from '../../ios/addFileToProject';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/addFileToProject-test.js
+++ b/packages/cli/src/link/__tests__/ios/addFileToProject-test.js
@@ -8,10 +8,11 @@
  * @emails oncall+javascript_foundation
  */
 
+import addFileToProject from '../../ios/addFileToProject';
+
 const xcode = require('xcode');
 const path = require('path');
 const _ = require('lodash');
-import addFileToProject from '../../ios/addFileToProject';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/addProjectToLibraries-test.js
+++ b/packages/cli/src/link/__tests__/ios/addProjectToLibraries-test.js
@@ -13,7 +13,7 @@ const path = require('path');
 const PbxFile = require('xcode/lib/pbxFile');
 const { last } = require('lodash');
 
-const addProjectToLibraries = require('../../ios/addProjectToLibraries');
+import addProjectToLibraries from '../../ios/addProjectToLibraries';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/addProjectToLibraries-test.js
+++ b/packages/cli/src/link/__tests__/ios/addProjectToLibraries-test.js
@@ -8,12 +8,12 @@
  * @emails oncall+javascript_foundation
  */
 
+import addProjectToLibraries from '../../ios/addProjectToLibraries';
+
 const xcode = require('xcode');
 const path = require('path');
 const PbxFile = require('xcode/lib/pbxFile');
 const { last } = require('lodash');
-
-import addProjectToLibraries from '../../ios/addProjectToLibraries';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/addSharedLibraries-test.js
+++ b/packages/cli/src/link/__tests__/ios/addSharedLibraries-test.js
@@ -8,10 +8,11 @@
  * @emails oncall+javascript_foundation
  */
 
-const xcode = require('xcode');
-const path = require('path');
 import addSharedLibraries from '../../ios/addSharedLibraries';
 import getGroup from '../../ios/getGroup';
+
+const xcode = require('xcode');
+const path = require('path');
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/addSharedLibraries-test.js
+++ b/packages/cli/src/link/__tests__/ios/addSharedLibraries-test.js
@@ -10,8 +10,8 @@
 
 const xcode = require('xcode');
 const path = require('path');
-const addSharedLibraries = require('../../ios/addSharedLibraries');
-const getGroup = require('../../ios/getGroup');
+import addSharedLibraries from '../../ios/addSharedLibraries';
+import getGroup from '../../ios/getGroup';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/createGroup-test.js
+++ b/packages/cli/src/link/__tests__/ios/createGroup-test.js
@@ -8,12 +8,12 @@
  * @emails oncall+javascript_foundation
  */
 
+import createGroup from '../../ios/createGroup';
+import getGroup from '../../ios/getGroup';
+
 const xcode = require('xcode');
 const path = require('path');
 const { last } = require('lodash');
-
-import createGroup from '../../ios/createGroup';
-import getGroup from '../../ios/getGroup';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/createGroup-test.js
+++ b/packages/cli/src/link/__tests__/ios/createGroup-test.js
@@ -12,8 +12,8 @@ const xcode = require('xcode');
 const path = require('path');
 const { last } = require('lodash');
 
-const createGroup = require('../../ios/createGroup');
-const getGroup = require('../../ios/getGroup');
+import createGroup from '../../ios/createGroup';
+import getGroup from '../../ios/getGroup';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/getBuildProperty-test.js
+++ b/packages/cli/src/link/__tests__/ios/getBuildProperty-test.js
@@ -8,9 +8,10 @@
  * @emails oncall+javascript_foundation
  */
 
+import getBuildProperty from '../../ios/getBuildProperty';
+
 const xcode = require('xcode');
 const path = require('path');
-import getBuildProperty from '../../ios/getBuildProperty';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/getBuildProperty-test.js
+++ b/packages/cli/src/link/__tests__/ios/getBuildProperty-test.js
@@ -10,7 +10,7 @@
 
 const xcode = require('xcode');
 const path = require('path');
-const getBuildProperty = require('../../ios/getBuildProperty');
+import getBuildProperty from '../../ios/getBuildProperty';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/getGroup-test.js
+++ b/packages/cli/src/link/__tests__/ios/getGroup-test.js
@@ -10,7 +10,7 @@
 
 const xcode = require('xcode');
 const path = require('path');
-const getGroup = require('../../ios/getGroup');
+import getGroup from '../../ios/getGroup';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/getGroup-test.js
+++ b/packages/cli/src/link/__tests__/ios/getGroup-test.js
@@ -8,9 +8,10 @@
  * @emails oncall+javascript_foundation
  */
 
+import getGroup from '../../ios/getGroup';
+
 const xcode = require('xcode');
 const path = require('path');
-import getGroup from '../../ios/getGroup';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/getHeaderSearchPath-test.js
+++ b/packages/cli/src/link/__tests__/ios/getHeaderSearchPath-test.js
@@ -9,7 +9,7 @@
  */
 
 const path = require('path');
-const getHeaderSearchPath = require('../../ios/getHeaderSearchPath');
+import getHeaderSearchPath from '../../ios/getHeaderSearchPath';
 
 const SRC_DIR = path.join('react-native-project', 'ios');
 

--- a/packages/cli/src/link/__tests__/ios/getHeaderSearchPath-test.js
+++ b/packages/cli/src/link/__tests__/ios/getHeaderSearchPath-test.js
@@ -8,8 +8,9 @@
  * @emails oncall+javascript_foundation
  */
 
-const path = require('path');
 import getHeaderSearchPath from '../../ios/getHeaderSearchPath';
+
+const path = require('path');
 
 const SRC_DIR = path.join('react-native-project', 'ios');
 

--- a/packages/cli/src/link/__tests__/ios/getHeadersInFolder-test.js
+++ b/packages/cli/src/link/__tests__/ios/getHeadersInFolder-test.js
@@ -12,7 +12,7 @@ jest.mock('fs');
 jest.mock('path');
 const fs = require('fs');
 
-const getHeadersInFolder = require('../../ios/getHeadersInFolder');
+import getHeadersInFolder from '../../ios/getHeadersInFolder';
 
 const ROOT_DIR = '/';
 

--- a/packages/cli/src/link/__tests__/ios/getHeadersInFolder-test.js
+++ b/packages/cli/src/link/__tests__/ios/getHeadersInFolder-test.js
@@ -8,11 +8,11 @@
  * @emails oncall+javascript_foundation
  */
 
+import getHeadersInFolder from '../../ios/getHeadersInFolder';
+
 jest.mock('fs');
 jest.mock('path');
 const fs = require('fs');
-
-import getHeadersInFolder from '../../ios/getHeadersInFolder';
 
 const ROOT_DIR = '/';
 

--- a/packages/cli/src/link/__tests__/ios/getPlist-test.js
+++ b/packages/cli/src/link/__tests__/ios/getPlist-test.js
@@ -8,9 +8,10 @@
  * @emails oncall+javascript_foundation
  */
 
+import getPlist from '../../ios/getPlist';
+
 const xcode = require('xcode');
 const path = require('path');
-import getPlist from '../../ios/getPlist';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/getPlist-test.js
+++ b/packages/cli/src/link/__tests__/ios/getPlist-test.js
@@ -10,7 +10,7 @@
 
 const xcode = require('xcode');
 const path = require('path');
-const getPlist = require('../../ios/getPlist');
+import getPlist from '../../ios/getPlist';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/getPlistPath-test.js
+++ b/packages/cli/src/link/__tests__/ios/getPlistPath-test.js
@@ -10,7 +10,7 @@
 
 const xcode = require('xcode');
 const path = require('path');
-const getPlistPath = require('../../ios/getPlistPath');
+import getPlistPath from '../../ios/getPlistPath';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/getPlistPath-test.js
+++ b/packages/cli/src/link/__tests__/ios/getPlistPath-test.js
@@ -8,9 +8,10 @@
  * @emails oncall+javascript_foundation
  */
 
+import getPlistPath from '../../ios/getPlistPath';
+
 const xcode = require('xcode');
 const path = require('path');
-import getPlistPath from '../../ios/getPlistPath';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/getTargets-test.js
+++ b/packages/cli/src/link/__tests__/ios/getTargets-test.js
@@ -8,9 +8,10 @@
  * @emails oncall+javascript_foundation
  */
 
+import getTargets from '../../ios/getTargets';
+
 const xcode = require('xcode');
 const path = require('path');
-import getTargets from '../../ios/getTargets';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/getTargets-test.js
+++ b/packages/cli/src/link/__tests__/ios/getTargets-test.js
@@ -10,7 +10,7 @@
 
 const xcode = require('xcode');
 const path = require('path');
-const getTargets = require('../../ios/getTargets');
+import getTargets from '../../ios/getTargets';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/hasLibraryImported-test.js
+++ b/packages/cli/src/link/__tests__/ios/hasLibraryImported-test.js
@@ -8,9 +8,10 @@
  * @emails oncall+javascript_foundation
  */
 
+import hasLibraryImported from '../../ios/hasLibraryImported';
+
 const xcode = require('xcode');
 const path = require('path');
-import hasLibraryImported from '../../ios/hasLibraryImported';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/hasLibraryImported-test.js
+++ b/packages/cli/src/link/__tests__/ios/hasLibraryImported-test.js
@@ -10,7 +10,7 @@
 
 const xcode = require('xcode');
 const path = require('path');
-const hasLibraryImported = require('../../ios/hasLibraryImported');
+import hasLibraryImported from '../../ios/hasLibraryImported';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/isInstalled-test.js
+++ b/packages/cli/src/link/__tests__/ios/isInstalled-test.js
@@ -9,7 +9,7 @@
  */
 
 const path = require('path');
-const isInstalled = require('../../ios/isInstalled');
+import isInstalled from '../../ios/isInstalled';
 
 const baseProjectConfig = {
   pbxprojPath: path.join(__dirname, '../../__fixtures__/project.pbxproj'),

--- a/packages/cli/src/link/__tests__/ios/isInstalled-test.js
+++ b/packages/cli/src/link/__tests__/ios/isInstalled-test.js
@@ -8,8 +8,9 @@
  * @emails oncall+javascript_foundation
  */
 
-const path = require('path');
 import isInstalled from '../../ios/isInstalled';
+
+const path = require('path');
 
 const baseProjectConfig = {
   pbxprojPath: path.join(__dirname, '../../__fixtures__/project.pbxproj'),

--- a/packages/cli/src/link/__tests__/ios/mapHeaderSearchPaths-test.js
+++ b/packages/cli/src/link/__tests__/ios/mapHeaderSearchPaths-test.js
@@ -8,9 +8,10 @@
  * @emails oncall+javascript_foundation
  */
 
+import mapHeaderSearchPaths from '../../ios/mapHeaderSearchPaths';
+
 const xcode = require('xcode');
 const path = require('path');
-import mapHeaderSearchPaths from '../../ios/mapHeaderSearchPaths';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/mapHeaderSearchPaths-test.js
+++ b/packages/cli/src/link/__tests__/ios/mapHeaderSearchPaths-test.js
@@ -10,7 +10,7 @@
 
 const xcode = require('xcode');
 const path = require('path');
-const mapHeaderSearchPaths = require('../../ios/mapHeaderSearchPaths');
+import mapHeaderSearchPaths from '../../ios/mapHeaderSearchPaths';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/removeProjectFromLibraries-test.js
+++ b/packages/cli/src/link/__tests__/ios/removeProjectFromLibraries-test.js
@@ -13,8 +13,8 @@ const PbxFile = require('xcode/lib/pbxFile');
 const path = require('path');
 const { last } = require('lodash');
 
-const addProjectToLibraries = require('../../ios/addProjectToLibraries');
-const removeProjectFromLibraries = require('../../ios/removeProjectFromLibraries');
+import addProjectToLibraries from '../../ios/addProjectToLibraries';
+import removeProjectFromLibraries from '../../ios/removeProjectFromLibraries';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/removeProjectFromLibraries-test.js
+++ b/packages/cli/src/link/__tests__/ios/removeProjectFromLibraries-test.js
@@ -8,13 +8,13 @@
  * @emails oncall+javascript_foundation
  */
 
+import addProjectToLibraries from '../../ios/addProjectToLibraries';
+import removeProjectFromLibraries from '../../ios/removeProjectFromLibraries';
+
 const xcode = require('xcode');
 const PbxFile = require('xcode/lib/pbxFile');
 const path = require('path');
 const { last } = require('lodash');
-
-import addProjectToLibraries from '../../ios/addProjectToLibraries';
-import removeProjectFromLibraries from '../../ios/removeProjectFromLibraries';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/removeProjectFromProject-test.js
+++ b/packages/cli/src/link/__tests__/ios/removeProjectFromProject-test.js
@@ -8,11 +8,12 @@
  * @emails oncall+javascript_foundation
  */
 
+import addFileToProject from '../../ios/addFileToProject';
+import removeProjectFromProject from '../../ios/removeProjectFromProject';
+
 const xcode = require('xcode');
 const pbxFile = require('xcode/lib/pbxFile');
 const path = require('path');
-import addFileToProject from '../../ios/addFileToProject';
-import removeProjectFromProject from '../../ios/removeProjectFromProject';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/removeProjectFromProject-test.js
+++ b/packages/cli/src/link/__tests__/ios/removeProjectFromProject-test.js
@@ -11,8 +11,8 @@
 const xcode = require('xcode');
 const pbxFile = require('xcode/lib/pbxFile');
 const path = require('path');
-const addFileToProject = require('../../ios/addFileToProject');
-const removeProjectFromProject = require('../../ios/removeProjectFromProject');
+import addFileToProject from '../../ios/addFileToProject';
+import removeProjectFromProject from '../../ios/removeProjectFromProject';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/removeSharedLibrary-test.js
+++ b/packages/cli/src/link/__tests__/ios/removeSharedLibrary-test.js
@@ -10,9 +10,9 @@
 
 const xcode = require('xcode');
 const path = require('path');
-const addSharedLibraries = require('../../ios/addSharedLibraries');
-const removeSharedLibraries = require('../../ios/removeSharedLibraries');
-const getGroup = require('../../ios/getGroup');
+import addSharedLibraries from '../../ios/addSharedLibraries';
+import removeSharedLibraries from '../../ios/removeSharedLibraries';
+import getGroup from '../../ios/getGroup';
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/removeSharedLibrary-test.js
+++ b/packages/cli/src/link/__tests__/ios/removeSharedLibrary-test.js
@@ -8,11 +8,12 @@
  * @emails oncall+javascript_foundation
  */
 
-const xcode = require('xcode');
-const path = require('path');
 import addSharedLibraries from '../../ios/addSharedLibraries';
 import removeSharedLibraries from '../../ios/removeSharedLibraries';
 import getGroup from '../../ios/getGroup';
+
+const xcode = require('xcode');
+const path = require('path');
 
 const project = xcode.project(
   path.join(__dirname, '../../__fixtures__/project.pbxproj')

--- a/packages/cli/src/link/__tests__/ios/writePlist-test.js
+++ b/packages/cli/src/link/__tests__/ios/writePlist-test.js
@@ -16,8 +16,8 @@ const { readFileSync } = jest.requireActual('fs');
 const fs = require('fs');
 
 const xcode = require('xcode');
-const getPlistPath = require('../../ios/getPlistPath');
-const writePlist = require('../../ios/writePlist');
+import getPlistPath from '../../ios/getPlistPath';
+import writePlist from '../../ios/writePlist';
 
 const realPath = jest.requireActual('path');
 const projectPath = realPath.join(

--- a/packages/cli/src/link/__tests__/ios/writePlist-test.js
+++ b/packages/cli/src/link/__tests__/ios/writePlist-test.js
@@ -8,6 +8,9 @@
  * @emails oncall+javascript_foundation
  */
 
+import getPlistPath from '../../ios/getPlistPath';
+import writePlist from '../../ios/writePlist';
+
 jest.mock('path');
 jest.mock('fs');
 jest.mock('../../ios/getPlistPath', () => jest.fn(() => null));
@@ -16,8 +19,6 @@ const { readFileSync } = jest.requireActual('fs');
 const fs = require('fs');
 
 const xcode = require('xcode');
-import getPlistPath from '../../ios/getPlistPath';
-import writePlist from '../../ios/writePlist';
 
 const realPath = jest.requireActual('path');
 const projectPath = realPath.join(

--- a/packages/cli/src/link/__tests__/link-test.js
+++ b/packages/cli/src/link/__tests__/link-test.js
@@ -100,6 +100,7 @@ describe('link', () => {
     jest.doMock('../ios/registerNativeModule.js', () => registerNativeModule);
 
     const link = require('../link').func;
+    registerNativeModule.mockClear();
 
     link(['react-native-blur'], context, {}).then(() => {
       expect(registerNativeModule.mock.calls).toHaveLength(2);
@@ -224,8 +225,8 @@ describe('link', () => {
     }));
 
     jest.doMock('../../core/getPlatforms', () => () => ({
-      ios: { linkConfig: require('../ios') },
-      android: { linkConfig: require('../android') },
+      ios: { linkConfig: require('../ios').default },
+      android: { linkConfig: require('../android').default },
       windows: { linkConfig: genericLinkConfig },
     }));
 
@@ -243,7 +244,6 @@ describe('link', () => {
     jest.doMock('../ios/registerNativeModule.js', () => registerNativeModule);
 
     const link = require('../link').func;
-
     link(['react-native-blur'], context, {}).then(() => {
       expect(registerNativeModule.mock.calls).toHaveLength(1);
       done();

--- a/packages/cli/src/link/__tests__/pods/findLineToAddPod-test.js
+++ b/packages/cli/src/link/__tests__/pods/findLineToAddPod-test.js
@@ -8,9 +8,10 @@
  * @emails oncall+javascript_foundation
  */
 
-const path = require('path');
 import findLineToAddPod from '../../pods/findLineToAddPod';
 import readPodfile from '../../pods/readPodfile';
+
+const path = require('path');
 
 const PODFILES_PATH = path.join(__dirname, '../../__fixtures__/pods');
 const LINE_AFTER_TARGET_IN_TEST_PODFILE = 4;

--- a/packages/cli/src/link/__tests__/pods/findLineToAddPod-test.js
+++ b/packages/cli/src/link/__tests__/pods/findLineToAddPod-test.js
@@ -9,8 +9,8 @@
  */
 
 const path = require('path');
-const findLineToAddPod = require('../../pods/findLineToAddPod');
-const readPodfile = require('../../pods/readPodfile');
+import findLineToAddPod from '../../pods/findLineToAddPod';
+import readPodfile from '../../pods/readPodfile';
 
 const PODFILES_PATH = path.join(__dirname, '../../__fixtures__/pods');
 const LINE_AFTER_TARGET_IN_TEST_PODFILE = 4;

--- a/packages/cli/src/link/__tests__/pods/findMarkedLinesInPodfile-test.js
+++ b/packages/cli/src/link/__tests__/pods/findMarkedLinesInPodfile-test.js
@@ -9,8 +9,8 @@
  */
 
 const path = require('path');
-const readPodfile = require('../../pods/readPodfile');
-const findMarkedLinesInPodfile = require('../../pods/findMarkedLinesInPodfile');
+import readPodfile from '../../pods/readPodfile';
+import findMarkedLinesInPodfile from '../../pods/findMarkedLinesInPodfile';
 
 const PODFILES_PATH = path.join(__dirname, '../../__fixtures__/pods');
 const LINE_AFTER_TARGET_IN_TEST_PODFILE = 4;

--- a/packages/cli/src/link/__tests__/pods/findMarkedLinesInPodfile-test.js
+++ b/packages/cli/src/link/__tests__/pods/findMarkedLinesInPodfile-test.js
@@ -8,9 +8,10 @@
  * @emails oncall+javascript_foundation
  */
 
-const path = require('path');
 import readPodfile from '../../pods/readPodfile';
 import findMarkedLinesInPodfile from '../../pods/findMarkedLinesInPodfile';
+
+const path = require('path');
 
 const PODFILES_PATH = path.join(__dirname, '../../__fixtures__/pods');
 const LINE_AFTER_TARGET_IN_TEST_PODFILE = 4;

--- a/packages/cli/src/link/__tests__/pods/findPodTargetLine-test.js
+++ b/packages/cli/src/link/__tests__/pods/findPodTargetLine-test.js
@@ -9,8 +9,8 @@
  */
 
 const path = require('path');
-const findPodTargetLine = require('../../pods/findPodTargetLine');
-const readPodfile = require('../../pods/readPodfile');
+import findPodTargetLine from '../../pods/findPodTargetLine';
+import readPodfile from '../../pods/readPodfile';
 
 const PODFILES_PATH = path.join(__dirname, '../../__fixtures__/pods');
 

--- a/packages/cli/src/link/__tests__/pods/findPodTargetLine-test.js
+++ b/packages/cli/src/link/__tests__/pods/findPodTargetLine-test.js
@@ -8,9 +8,10 @@
  * @emails oncall+javascript_foundation
  */
 
-const path = require('path');
 import findPodTargetLine from '../../pods/findPodTargetLine';
 import readPodfile from '../../pods/readPodfile';
+
+const path = require('path');
 
 const PODFILES_PATH = path.join(__dirname, '../../__fixtures__/pods');
 

--- a/packages/cli/src/link/__tests__/pods/isInstalled-test.js
+++ b/packages/cli/src/link/__tests__/pods/isInstalled-test.js
@@ -8,8 +8,9 @@
  * @emails oncall+javascript_foundation
  */
 
-const path = require('path');
 import isInstalled from '../../pods/isInstalled';
+
+const path = require('path');
 
 const PODFILES_PATH = path.join(__dirname, '../../__fixtures__/pods');
 

--- a/packages/cli/src/link/__tests__/pods/isInstalled-test.js
+++ b/packages/cli/src/link/__tests__/pods/isInstalled-test.js
@@ -9,7 +9,7 @@
  */
 
 const path = require('path');
-const isInstalled = require('../../pods/isInstalled');
+import isInstalled from '../../pods/isInstalled';
 
 const PODFILES_PATH = path.join(__dirname, '../../__fixtures__/pods');
 

--- a/packages/cli/src/link/__tests__/pods/removePodEntry-test.js
+++ b/packages/cli/src/link/__tests__/pods/removePodEntry-test.js
@@ -8,9 +8,10 @@
  * @emails oncall+javascript_foundation
  */
 
-const path = require('path');
 import removePodEntry from '../../pods/removePodEntry';
 import readPodfile from '../../pods/readPodfile';
+
+const path = require('path');
 
 const PODFILES_PATH = path.join(__dirname, '../../__fixtures__/pods');
 

--- a/packages/cli/src/link/__tests__/pods/removePodEntry-test.js
+++ b/packages/cli/src/link/__tests__/pods/removePodEntry-test.js
@@ -9,8 +9,8 @@
  */
 
 const path = require('path');
-const removePodEntry = require('../../pods/removePodEntry');
-const readPodfile = require('../../pods/readPodfile');
+import removePodEntry from '../../pods/removePodEntry';
+import readPodfile from '../../pods/readPodfile';
 
 const PODFILES_PATH = path.join(__dirname, '../../__fixtures__/pods');
 

--- a/packages/cli/src/link/__tests__/promiseWaterfall-test.js
+++ b/packages/cli/src/link/__tests__/promiseWaterfall-test.js
@@ -8,7 +8,7 @@
  * @emails oncall+javascript_foundation
  */
 
-const promiseWaterfall = require('../promiseWaterfall');
+import promiseWaterfall from '../promiseWaterfall';
 
 describe('promiseWaterfall', () => {
   it('should run promises in a sequence', async () => {

--- a/packages/cli/src/link/android/copyAssets.js
+++ b/packages/cli/src/link/android/copyAssets.js
@@ -17,7 +17,7 @@ import groupFilesByType from '../groupFilesByType';
  * For now, the only types of files that are handled are:
  * - Fonts (otf, ttf) - copied to targetPath/fonts under original name
  */
-module.exports = function copyAssetsAndroid(files, project) {
+export default function copyAssetsAndroid(files, project) {
   const assets = groupFilesByType(files);
 
   (assets.font || []).forEach(asset =>
@@ -26,4 +26,4 @@ module.exports = function copyAssetsAndroid(files, project) {
       path.join(project.assetsPath, 'fonts', path.basename(asset))
     )
   );
-};
+}

--- a/packages/cli/src/link/android/index.js
+++ b/packages/cli/src/link/android/index.js
@@ -7,12 +7,14 @@
  * @format
  */
 
-module.exports = function getAndroidLinkConfig() {
-  return {
-    isInstalled: require('./isInstalled'),
-    register: require('./registerNativeModule'),
-    unregister: require('./unregisterNativeModule'),
-    copyAssets: require('./copyAssets'),
-    unlinkAssets: require('./unlinkAssets'),
-  };
-};
+import isInstalled from './isInstalled';
+import register from './registerNativeModule';
+import unregister from './unregisterNativeModule';
+import copyAssets from './copyAssets';
+import unlinkAssets from './unlinkAssets';
+
+export function getAndroidLinkConfig() {
+  return { isInstalled, register, unregister, copyAssets, unlinkAssets };
+}
+
+export default getAndroidLinkConfig;

--- a/packages/cli/src/link/android/isInstalled.js
+++ b/packages/cli/src/link/android/isInstalled.js
@@ -10,7 +10,7 @@
 import fs from 'fs';
 import makeBuildPatch from './patches/makeBuildPatch';
 
-module.exports = function isInstalled(config, name) {
+export default function isInstalled(config, name) {
   const buildGradle = fs.readFileSync(config.buildGradlePath);
   return makeBuildPatch(name).installPattern.test(buildGradle);
-};
+}

--- a/packages/cli/src/link/android/patches/applyParams.js
+++ b/packages/cli/src/link/android/patches/applyParams.js
@@ -9,10 +9,10 @@
 
 import { camelCase as toCamelCase } from 'lodash';
 
-module.exports = function applyParams(str, params, prefix) {
+export default function applyParams(str, params, prefix) {
   return str.replace(/\$\{(\w+)\}/g, (pattern, param) => {
     const name = `${toCamelCase(prefix)}_${param}`;
 
     return params[param] ? `getResources().getString(R.string.${name})` : null;
   });
-};
+}

--- a/packages/cli/src/link/android/patches/applyPatch.js
+++ b/packages/cli/src/link/android/patches/applyPatch.js
@@ -9,11 +9,11 @@
 
 import fs from 'fs';
 
-module.exports = function applyPatch(file, patch) {
+export default function applyPatch(file, patch) {
   fs.writeFileSync(
     file,
     fs
       .readFileSync(file, 'utf8')
       .replace(patch.pattern, match => `${match}${patch.patch}`)
   );
-};
+}

--- a/packages/cli/src/link/android/patches/makeBuildPatch.js
+++ b/packages/cli/src/link/android/patches/makeBuildPatch.js
@@ -9,7 +9,7 @@
 
 import normalizeProjectName from './normalizeProjectName';
 
-module.exports = function makeBuildPatch(name) {
+export default function makeBuildPatch(name) {
   const normalizedProjectName = normalizeProjectName(name);
   const installPattern = new RegExp(
     `(implementation|api|compile)\\w*\\s*\\(*project\\(['"]:${normalizedProjectName}['"]\\)`
@@ -20,4 +20,4 @@ module.exports = function makeBuildPatch(name) {
     pattern: /[^ \t]dependencies {(\r\n|\n)/,
     patch: `    implementation project(':${normalizedProjectName}')\n`,
   };
-};
+}

--- a/packages/cli/src/link/android/patches/makeImportPatch.js
+++ b/packages/cli/src/link/android/patches/makeImportPatch.js
@@ -7,9 +7,9 @@
  * @format
  */
 
-module.exports = function makeImportPatch(packageImportPath) {
+export default function makeImportPatch(packageImportPath) {
   return {
     pattern: 'import com.facebook.react.ReactApplication;',
     patch: `\n${packageImportPath}`,
   };
-};
+}

--- a/packages/cli/src/link/android/patches/makePackagePatch.js
+++ b/packages/cli/src/link/android/patches/makePackagePatch.js
@@ -9,11 +9,11 @@
 
 import applyParams from './applyParams';
 
-module.exports = function makePackagePatch(packageInstance, params, prefix) {
+export default function makePackagePatch(packageInstance, params, prefix) {
   const processedInstance = applyParams(packageInstance, params, prefix);
 
   return {
     pattern: 'new MainReactPackage()',
     patch: `,\n            ${processedInstance}`,
   };
-};
+}

--- a/packages/cli/src/link/android/patches/makeSettingsPatch.js
+++ b/packages/cli/src/link/android/patches/makeSettingsPatch.js
@@ -11,11 +11,7 @@ import path from 'path';
 import slash from 'slash';
 import normalizeProjectName from './normalizeProjectName';
 
-module.exports = function makeSettingsPatch(
-  name,
-  androidConfig,
-  projectConfig
-) {
+export default function makeSettingsPatch(name, androidConfig, projectConfig) {
   // Gradle expects paths to be posix even on Windows
   const projectDir = slash(
     path.relative(
@@ -32,4 +28,4 @@ module.exports = function makeSettingsPatch(
       `project(':${normalizedProjectName}').projectDir = ` +
       `new File(rootProject.projectDir, '${projectDir}')\n`,
   };
-};
+}

--- a/packages/cli/src/link/android/patches/makeStringsPatch.js
+++ b/packages/cli/src/link/android/patches/makeStringsPatch.js
@@ -9,7 +9,7 @@
 
 import { camelCase as toCamelCase } from 'lodash';
 
-module.exports = function makeStringsPatch(params, prefix) {
+export default function makeStringsPatch(params, prefix) {
   const values = Object.keys(params).map(param => {
     const name = `${toCamelCase(prefix)}_${param}`;
     return (
@@ -24,4 +24,4 @@ module.exports = function makeStringsPatch(params, prefix) {
     pattern: '<resources>\n',
     patch,
   };
-};
+}

--- a/packages/cli/src/link/android/patches/normalizeProjectName.js
+++ b/packages/cli/src/link/android/patches/normalizeProjectName.js
@@ -7,6 +7,6 @@
  * @format
  */
 
-module.exports = function normalizeProjectName(name) {
+export default function normalizeProjectName(name) {
   return name.replace(/\//g, '_');
-};
+}

--- a/packages/cli/src/link/android/patches/revokePatch.js
+++ b/packages/cli/src/link/android/patches/revokePatch.js
@@ -9,9 +9,9 @@
 
 import fs from 'fs';
 
-module.exports = function revokePatch(file, patch) {
+export default function revokePatch(file, patch) {
   fs.writeFileSync(
     file,
     fs.readFileSync(file, 'utf8').replace(patch.patch, '')
   );
-};
+}

--- a/packages/cli/src/link/android/registerNativeModule.js
+++ b/packages/cli/src/link/android/registerNativeModule.js
@@ -14,7 +14,7 @@ import makeBuildPatch from './patches/makeBuildPatch';
 import makeImportPatch from './patches/makeImportPatch';
 import makePackagePatch from './patches/makePackagePatch';
 
-module.exports = function registerNativeAndroidModule(
+export default function registerNativeAndroidModule(
   name,
   androidConfig,
   params,
@@ -39,4 +39,4 @@ module.exports = function registerNativeAndroidModule(
     projectConfig.mainFilePath,
     makeImportPatch(androidConfig.packageImportPath)
   );
-};
+}

--- a/packages/cli/src/link/android/unlinkAssets.js
+++ b/packages/cli/src/link/android/unlinkAssets.js
@@ -17,7 +17,7 @@ import groupFilesByType from '../groupFilesByType';
  * For now, the only types of files that are handled are:
  * - Fonts (otf, ttf) - copied to targetPath/fonts under original name
  */
-module.exports = function unlinkAssetsAndroid(files, project) {
+export default function unlinkAssetsAndroid(files, project) {
   const assets = groupFilesByType(files);
 
   (assets.font || []).forEach(file => {
@@ -30,4 +30,4 @@ module.exports = function unlinkAssetsAndroid(files, project) {
       fs.unlinkSync(filePath);
     }
   });
-};
+}

--- a/packages/cli/src/link/android/unregisterNativeModule.js
+++ b/packages/cli/src/link/android/unregisterNativeModule.js
@@ -17,7 +17,7 @@ import makeStringsPatch from './patches/makeStringsPatch';
 import makeImportPatch from './patches/makeImportPatch';
 import makePackagePatch from './patches/makePackagePatch';
 
-module.exports = function unregisterNativeAndroidModule(
+export default function unregisterNativeAndroidModule(
   name,
   androidConfig,
   projectConfig
@@ -50,4 +50,4 @@ module.exports = function unregisterNativeAndroidModule(
     projectConfig.mainFilePath,
     makeImportPatch(androidConfig.packageImportPath)
   );
-};
+}

--- a/packages/cli/src/link/commandStub.js
+++ b/packages/cli/src/link/commandStub.js
@@ -7,4 +7,4 @@
  * @format
  */
 
-module.exports = cb => cb();
+export default cb => cb();

--- a/packages/cli/src/link/getDependencyConfig.js
+++ b/packages/cli/src/link/getDependencyConfig.js
@@ -24,7 +24,7 @@ type DependenciesConfig = {
   params: InquirerPromptT[],
 };
 
-module.exports = function getDependencyConfig(
+export default function getDependencyConfig(
   ctx: ContextT,
   availablePlatforms: PlatformsT,
   dependency: string
@@ -53,4 +53,4 @@ module.exports = function getDependencyConfig(
   } catch (e) {
     throw new Error('Failed to get dependency config');
   }
-};
+}

--- a/packages/cli/src/link/getProjectConfig.js
+++ b/packages/cli/src/link/getProjectConfig.js
@@ -6,7 +6,7 @@ import type { PlatformsT, ContextT, ProjectConfigT } from '../core/types.flow';
 
 import getPackageConfiguration from '../core/getPackageConfiguration';
 
-module.exports = function getProjectConfig(
+export default function getProjectConfig(
   ctx: ContextT,
   availablePlatforms: PlatformsT
 ): ProjectConfigT {
@@ -22,4 +22,4 @@ module.exports = function getProjectConfig(
   });
 
   return platformConfigs;
-};
+}

--- a/packages/cli/src/link/getProjectDependencies.js
+++ b/packages/cli/src/link/getProjectDependencies.js
@@ -23,9 +23,9 @@ const EXCLUDED_PROJECTS = [
 /**
  * Returns an array of dependencies that should be linked/checked.
  */
-module.exports = function getProjectDependencies(cwd) {
+export default function getProjectDependencies(cwd) {
   const pjson = require(path.join(cwd, './package.json'));
   return Object.keys(pjson.dependencies || {}).filter(
     name => EXCLUDED_PROJECTS.includes(name) === false
   );
-};
+}

--- a/packages/cli/src/link/groupFilesByType.js
+++ b/packages/cli/src/link/groupFilesByType.js
@@ -31,6 +31,6 @@ mime.define({
  * Given an array ['fonts/a.ttf', 'images/b.jpg'],
  * the returned object will be: {font: ['fonts/a.ttf'], image: ['images/b.jpg']}
  */
-module.exports = function groupFilesByType(assets) {
+export default function groupFilesByType(assets) {
   return groupBy(assets, type => mime.lookup(type).split('/')[0]);
-};
+}

--- a/packages/cli/src/link/ios/addFileToProject.js
+++ b/packages/cli/src/link/ios/addFileToProject.js
@@ -14,10 +14,10 @@ import PbxFile from 'xcode/lib/pbxFile';
  * from path provided, adds it to the project
  * and returns newly created instance of a file
  */
-module.exports = function addFileToProject(project, filePath) {
+export default function addFileToProject(project, filePath) {
   const file = new PbxFile(filePath);
   file.uuid = project.generateUuid();
   file.fileRef = project.generateUuid();
   project.addToPbxFileReferenceSection(file);
   return file;
-};
+}

--- a/packages/cli/src/link/ios/addProjectToLibraries.js
+++ b/packages/cli/src/link/ios/addProjectToLibraries.js
@@ -14,9 +14,9 @@
  * Important: That function mutates `libraries` and it's not pure.
  * It's mainly due to limitations of `xcode` library.
  */
-module.exports = function addProjectToLibraries(libraries, file) {
+export default function addProjectToLibraries(libraries, file) {
   return libraries.children.push({
     value: file.fileRef,
     comment: file.basename,
   });
-};
+}

--- a/packages/cli/src/link/ios/addSharedLibraries.js
+++ b/packages/cli/src/link/ios/addSharedLibraries.js
@@ -9,7 +9,7 @@
 
 import createGroupWithMessage from './createGroupWithMessage';
 
-module.exports = function addSharedLibraries(project, libraries) {
+export default function addSharedLibraries(project, libraries) {
   if (!libraries.length) {
     return;
   }
@@ -22,4 +22,4 @@ module.exports = function addSharedLibraries(project, libraries) {
   for (const name of libraries) {
     project.addFramework(name, { target });
   }
-};
+}

--- a/packages/cli/src/link/ios/addToHeaderSearchPaths.js
+++ b/packages/cli/src/link/ios/addToHeaderSearchPaths.js
@@ -9,6 +9,6 @@
 
 import mapHeaderSearchPaths from './mapHeaderSearchPaths';
 
-module.exports = function addToHeaderSearchPaths(project, path) {
+export default function addToHeaderSearchPaths(project, path) {
   mapHeaderSearchPaths(project, searchPaths => searchPaths.concat(path));
-};
+}

--- a/packages/cli/src/link/ios/common/isInstalled.js
+++ b/packages/cli/src/link/ios/common/isInstalled.js
@@ -10,9 +10,9 @@
 import isInstalledIOS from '../isInstalled';
 import isInstalledPods from '../../pods/isInstalled';
 
-module.exports = function isInstalled(projectConfig, name, dependencyConfig) {
+export default function isInstalled(projectConfig, name, dependencyConfig) {
   return (
     isInstalledIOS(projectConfig, dependencyConfig) ||
     isInstalledPods(projectConfig, dependencyConfig)
   );
-};
+}

--- a/packages/cli/src/link/ios/common/registerNativeModule.js
+++ b/packages/cli/src/link/ios/common/registerNativeModule.js
@@ -10,7 +10,7 @@
 import registerDependencyIOS from '../registerNativeModule';
 import registerDependencyPods from '../../pods/registerNativeModule';
 
-module.exports = function registerNativeModule(
+export default function registerNativeModule(
   name,
   dependencyConfig,
   params,
@@ -21,4 +21,4 @@ module.exports = function registerNativeModule(
   } else {
     registerDependencyIOS(dependencyConfig, projectConfig);
   }
-};
+}

--- a/packages/cli/src/link/ios/common/unregisterNativeModule.js
+++ b/packages/cli/src/link/ios/common/unregisterNativeModule.js
@@ -13,7 +13,7 @@ import isInstalledPods from '../../pods/isInstalled';
 import unregisterDependencyIOS from '../unregisterNativeModule';
 import unregisterDependencyPods from '../../pods/unregisterNativeModule';
 
-module.exports = function unregisterNativeModule(
+export default function unregisterNativeModule(
   name,
   dependencyConfig,
   projectConfig,
@@ -27,4 +27,4 @@ module.exports = function unregisterNativeModule(
   } else if (isPodInstalled) {
     unregisterDependencyPods(dependencyConfig, projectConfig);
   }
-};
+}

--- a/packages/cli/src/link/ios/copyAssets.js
+++ b/packages/cli/src/link/ios/copyAssets.js
@@ -19,7 +19,7 @@ import writePlist from './writePlist';
  * This function works in a similar manner to its Android version,
  * except it does not copy fonts but creates Xcode Group references
  */
-module.exports = function linkAssetsIOS(files, projectConfig) {
+export default function linkAssetsIOS(files, projectConfig) {
   const project = xcode.project(projectConfig.pbxprojPath).parseSync();
   const assets = groupFilesByType(files);
   const plist = getPlist(project, projectConfig.sourceDir);
@@ -48,4 +48,4 @@ module.exports = function linkAssetsIOS(files, projectConfig) {
   fs.writeFileSync(projectConfig.pbxprojPath, project.writeSync());
 
   writePlist(project, projectConfig.sourceDir, plist);
-};
+}

--- a/packages/cli/src/link/ios/createGroup.js
+++ b/packages/cli/src/link/ios/createGroup.js
@@ -18,7 +18,7 @@ const hasGroup = (pbxGroup, name) =>
  *
  * Returns newly created group
  */
-module.exports = function createGroup(project, path) {
+export default function createGroup(project, path) {
   return path.split('/').reduce((group, name) => {
     if (!hasGroup(group, name)) {
       const uuid = project.pbxCreateGroup(name, '""');
@@ -31,4 +31,4 @@ module.exports = function createGroup(project, path) {
 
     return project.pbxGroupByName(name);
   }, getGroup(project));
-};
+}

--- a/packages/cli/src/link/ios/createGroupWithMessage.js
+++ b/packages/cli/src/link/ios/createGroupWithMessage.js
@@ -17,7 +17,7 @@ import getGroup from './getGroup';
  *
  * Returns the existing or newly created group
  */
-module.exports = function createGroupWithMessage(project, path) {
+export default function createGroupWithMessage(project, path) {
   let group = getGroup(project, path);
 
   if (!group) {
@@ -29,4 +29,4 @@ module.exports = function createGroupWithMessage(project, path) {
   }
 
   return group;
-};
+}

--- a/packages/cli/src/link/ios/getBuildProperty.js
+++ b/packages/cli/src/link/ios/getBuildProperty.js
@@ -18,7 +18,7 @@
  * without the property defined (e.g. CocoaPods sections appended to project
  * miss INFOPLIST_FILE), see: https://github.com/alunny/node-xcode/blob/master/lib/pbxProject.js#L1765
  */
-module.exports = function getBuildProperty(project, prop) {
+export default function getBuildProperty(project, prop) {
   const target = project.getFirstTarget().firstTarget;
   const config = project.pbxXCConfigurationList()[
     target.buildConfigurationList
@@ -28,4 +28,4 @@ module.exports = function getBuildProperty(project, prop) {
   ];
 
   return buildSection.buildSettings[prop];
-};
+}

--- a/packages/cli/src/link/ios/getGroup.js
+++ b/packages/cli/src/link/ios/getGroup.js
@@ -20,7 +20,7 @@ const findGroup = (groups, name) =>
  *
  * If path is not provided, it returns top-level group
  */
-module.exports = function getGroup(project, path) {
+export default function getGroup(project, path) {
   const firstProject = getFirstProject(project);
 
   let groups = project.getPBXGroupByKey(firstProject.mainGroup);
@@ -41,4 +41,4 @@ module.exports = function getGroup(project, path) {
   }
 
   return groups;
-};
+}

--- a/packages/cli/src/link/ios/getHeaderSearchPath.js
+++ b/packages/cli/src/link/ios/getHeaderSearchPath.js
@@ -49,7 +49,7 @@ const getOuterDirectory = directories =>
  * the end so Xcode marks that location as `recursive` and will look inside
  * every folder of it to locate correct headers.
  */
-module.exports = function getHeaderSearchPath(sourceDir, headers) {
+export default function getHeaderSearchPath(sourceDir, headers) {
   const directories = union(headers.map(path.dirname));
 
   return directories.length === 1
@@ -58,4 +58,4 @@ module.exports = function getHeaderSearchPath(sourceDir, headers) {
         sourceDir,
         getOuterDirectory(directories)
       )}/**"`;
-};
+}

--- a/packages/cli/src/link/ios/getHeadersInFolder.js
+++ b/packages/cli/src/link/ios/getHeadersInFolder.js
@@ -21,7 +21,7 @@ const GLOB_EXCLUDE_PATTERN = [
  * Given folder, it returns an array of all header files
  * inside it, ignoring node_modules and examples
  */
-module.exports = function getHeadersInFolder(folder) {
+export default function getHeadersInFolder(folder) {
   return glob
     .sync('**/*.h', {
       cwd: folder,
@@ -29,4 +29,4 @@ module.exports = function getHeadersInFolder(folder) {
       ignore: GLOB_EXCLUDE_PATTERN,
     })
     .map(file => path.join(folder, file));
-};
+}

--- a/packages/cli/src/link/ios/getPlist.js
+++ b/packages/cli/src/link/ios/getPlist.js
@@ -16,7 +16,7 @@ import getPlistPath from './getPlistPath';
  *
  * Returns `null` if INFOPLIST_FILE is not specified.
  */
-module.exports = function getPlist(project, sourceDir) {
+export default function getPlist(project, sourceDir) {
   const plistPath = getPlistPath(project, sourceDir);
 
   if (!plistPath || !fs.existsSync(plistPath)) {
@@ -24,4 +24,4 @@ module.exports = function getPlist(project, sourceDir) {
   }
 
   return plistParser.parse(fs.readFileSync(plistPath, 'utf-8'));
-};
+}

--- a/packages/cli/src/link/ios/getPlistPath.js
+++ b/packages/cli/src/link/ios/getPlistPath.js
@@ -10,7 +10,7 @@
 import path from 'path';
 import getBuildProperty from './getBuildProperty';
 
-module.exports = function getPlistPath(project, sourceDir) {
+export default function getPlistPath(project, sourceDir) {
   const plistFile = getBuildProperty(project, 'INFOPLIST_FILE');
 
   if (!plistFile) {
@@ -21,4 +21,4 @@ module.exports = function getPlistPath(project, sourceDir) {
     sourceDir,
     plistFile.replace(/"/g, '').replace('$(SRCROOT)', '')
   );
-};
+}

--- a/packages/cli/src/link/ios/getTargets.js
+++ b/packages/cli/src/link/ios/getTargets.js
@@ -10,7 +10,7 @@
 /**
  * Given xcodeproj it returns list of targets
  */
-module.exports = function getTargets(project) {
+export default function getTargets(project) {
   const {
     firstProject: { targets },
   } = project.getFirstProject();
@@ -36,4 +36,4 @@ module.exports = function getTargets(project) {
         false,
     };
   });
-};
+}

--- a/packages/cli/src/link/ios/hasLibraryImported.js
+++ b/packages/cli/src/link/ios/hasLibraryImported.js
@@ -12,9 +12,9 @@
  * added, returns true or false depending on whether the library is already linked
  * or not
  */
-module.exports = function hasLibraryImported(libraries, packageName) {
+export default function hasLibraryImported(libraries, packageName) {
   return (
     libraries.children.filter(library => library.comment === packageName)
       .length > 0
   );
-};
+}

--- a/packages/cli/src/link/ios/index.js
+++ b/packages/cli/src/link/ios/index.js
@@ -7,12 +7,14 @@
  * @format
  */
 
-module.exports = function getIOSLinkConfig() {
-  return {
-    isInstalled: require('./common/isInstalled'),
-    register: require('./common/registerNativeModule'),
-    unregister: require('./common/unregisterNativeModule'),
-    copyAssets: require('./copyAssets'),
-    unlinkAssets: require('./unlinkAssets'),
-  };
-};
+import isInstalled from './common/isInstalled';
+import register from './common/registerNativeModule';
+import unregister from './common/unregisterNativeModule';
+import copyAssets from './copyAssets';
+import unlinkAssets from './unlinkAssets';
+
+export function getIOSLinkConfig() {
+  return { isInstalled, register, unregister, copyAssets, unlinkAssets };
+}
+
+export default getIOSLinkConfig;

--- a/packages/cli/src/link/ios/isInstalled.js
+++ b/packages/cli/src/link/ios/isInstalled.js
@@ -15,7 +15,7 @@ import hasLibraryImported from './hasLibraryImported';
  * Returns true if `xcodeproj` specified by dependencyConfig is present
  * in a top level `libraryFolder`
  */
-module.exports = function isInstalled(projectConfig, dependencyConfig) {
+export default function isInstalled(projectConfig, dependencyConfig) {
   const project = xcode.project(projectConfig.pbxprojPath).parseSync();
   const libraries = getGroup(project, projectConfig.libraryFolder);
 
@@ -24,4 +24,4 @@ module.exports = function isInstalled(projectConfig, dependencyConfig) {
   }
 
   return hasLibraryImported(libraries, dependencyConfig.projectName);
-};
+}

--- a/packages/cli/src/link/ios/mapHeaderSearchPaths.js
+++ b/packages/cli/src/link/ios/mapHeaderSearchPaths.js
@@ -24,7 +24,7 @@
  */
 const defaultHeaderPaths = ['"$(inherited)"'];
 
-module.exports = function headerSearchPathIter(project, func) {
+export default function headerSearchPathIter(project, func) {
   const config = project.pbxXCBuildConfigurationSection();
 
   Object.keys(config)
@@ -45,4 +45,4 @@ module.exports = function headerSearchPathIter(project, func) {
         buildSettings.HEADER_SEARCH_PATHS = func(searchPaths);
       }
     });
-};
+}

--- a/packages/cli/src/link/ios/registerNativeModule.js
+++ b/packages/cli/src/link/ios/registerNativeModule.js
@@ -28,7 +28,7 @@ import addSharedLibraries from './addSharedLibraries';
  *
  * If library is already linked, this action is a no-op.
  */
-module.exports = function registerNativeModuleIOS(
+export default function registerNativeModuleIOS(
   dependencyConfig,
   projectConfig
 ) {
@@ -84,4 +84,4 @@ module.exports = function registerNativeModuleIOS(
   }
 
   fs.writeFileSync(projectConfig.pbxprojPath, project.writeSync());
-};
+}

--- a/packages/cli/src/link/ios/removeFromHeaderSearchPaths.js
+++ b/packages/cli/src/link/ios/removeFromHeaderSearchPaths.js
@@ -12,8 +12,8 @@ import mapHeaderSearchPaths from './mapHeaderSearchPaths';
 /**
  * Given Xcode project and absolute path, it makes sure there are no headers referring to it
  */
-module.exports = function addToHeaderSearchPaths(project, path) {
+export default function addToHeaderSearchPaths(project, path) {
   mapHeaderSearchPaths(project, searchPaths =>
     searchPaths.filter(searchPath => searchPath !== path)
   );
-};
+}

--- a/packages/cli/src/link/ios/removeFromPbxItemContainerProxySection.js
+++ b/packages/cli/src/link/ios/removeFromPbxItemContainerProxySection.js
@@ -12,10 +12,7 @@
  * a new PBXItemContainerProxy is created that contains `containerPortal` value
  * which equals to xcodeproj file.uuid from PBXFileReference section.
  */
-module.exports = function removeFromPbxItemContainerProxySection(
-  project,
-  file
-) {
+export default function removeFromPbxItemContainerProxySection(project, file) {
   const section = project.hash.project.objects.PBXContainerItemProxy;
 
   for (const key of Object.keys(section)) {
@@ -23,4 +20,4 @@ module.exports = function removeFromPbxItemContainerProxySection(
       delete section[key];
     }
   }
-};
+}

--- a/packages/cli/src/link/ios/removeFromPbxReferenceProxySection.js
+++ b/packages/cli/src/link/ios/removeFromPbxReferenceProxySection.js
@@ -11,7 +11,7 @@
  * Every file added to the project from another project is attached to
  * `PBXItemContainerProxy` through `PBXReferenceProxy`.
  */
-module.exports = function removeFromPbxReferenceProxySection(project, file) {
+export default function removeFromPbxReferenceProxySection(project, file) {
   const section = project.hash.project.objects.PBXReferenceProxy;
 
   for (const key of Object.keys(section)) {
@@ -19,4 +19,4 @@ module.exports = function removeFromPbxReferenceProxySection(project, file) {
       delete section[key];
     }
   }
-};
+}

--- a/packages/cli/src/link/ios/removeFromProjectReferences.js
+++ b/packages/cli/src/link/ios/removeFromProjectReferences.js
@@ -17,7 +17,7 @@
  *
  * Otherwise returns null
  */
-module.exports = function removeFromProjectReferences(project, file) {
+export default function removeFromProjectReferences(project, file) {
   const { firstProject } = project.getFirstProject();
 
   const projectRef = firstProject.projectReferences.find(
@@ -34,4 +34,4 @@ module.exports = function removeFromProjectReferences(project, file) {
   );
 
   return projectRef;
-};
+}

--- a/packages/cli/src/link/ios/removeFromStaticLibraries.js
+++ b/packages/cli/src/link/ios/removeFromStaticLibraries.js
@@ -15,7 +15,7 @@ import removeFromPbxReferenceProxySection from './removeFromPbxReferenceProxySec
  *
  * Similar to `node-xcode` addStaticLibrary
  */
-module.exports = function removeFromStaticLibraries(project, path, opts) {
+export default function removeFromStaticLibraries(project, path, opts) {
   const file = new PbxFile(path);
 
   file.target = opts ? opts.target : undefined;
@@ -27,4 +27,4 @@ module.exports = function removeFromStaticLibraries(project, path, opts) {
   removeFromPbxReferenceProxySection(project, file);
 
   return file;
-};
+}

--- a/packages/cli/src/link/ios/removeProductGroup.js
+++ b/packages/cli/src/link/ios/removeProductGroup.js
@@ -7,7 +7,7 @@
  * @format
  */
 
-module.exports = function removeProductGroup(project, productGroupId) {
+export default function removeProductGroup(project, productGroupId) {
   const section = project.hash.project.objects.PBXGroup;
 
   for (const key of Object.keys(section)) {
@@ -15,4 +15,4 @@ module.exports = function removeProductGroup(project, productGroupId) {
       delete section[key];
     }
   }
-};
+}

--- a/packages/cli/src/link/ios/removeProjectFromLibraries.js
+++ b/packages/cli/src/link/ios/removeProjectFromLibraries.js
@@ -12,9 +12,9 @@
  * Important: That function mutates `libraries` and it's not pure.
  * It's mainly due to limitations of `xcode` library.
  */
-module.exports = function removeProjectFromLibraries(libraries, file) {
+export default function removeProjectFromLibraries(libraries, file) {
   // eslint-disable-next-line no-param-reassign
   libraries.children = libraries.children.filter(
     library => library.comment !== file.basename
   );
-};
+}

--- a/packages/cli/src/link/ios/removeProjectFromProject.js
+++ b/packages/cli/src/link/ios/removeProjectFromProject.js
@@ -21,7 +21,7 @@ import removeProductGroup from './removeProductGroup';
  *
  * Returns removed file (that one will have UUID)
  */
-module.exports = function removeProjectFromProject(project, filePath) {
+export default function removeProjectFromProject(project, filePath) {
   const file = project.removeFromPbxFileReferenceSection(new PbxFile(filePath));
   const projectRef = removeFromProjectReferences(project, file);
 
@@ -32,4 +32,4 @@ module.exports = function removeProjectFromProject(project, filePath) {
   removeFromPbxItemContainerProxySection(project, file);
 
   return file;
-};
+}

--- a/packages/cli/src/link/ios/removeSharedLibraries.js
+++ b/packages/cli/src/link/ios/removeSharedLibraries.js
@@ -7,7 +7,7 @@
  * @format
  */
 
-module.exports = function removeSharedLibraries(project, libraries) {
+export default function removeSharedLibraries(project, libraries) {
   if (!libraries.length) {
     return;
   }
@@ -17,4 +17,4 @@ module.exports = function removeSharedLibraries(project, libraries) {
   for (const name of libraries) {
     project.removeFramework(name, { target });
   }
-};
+}

--- a/packages/cli/src/link/ios/unlinkAssets.js
+++ b/packages/cli/src/link/ios/unlinkAssets.js
@@ -20,7 +20,7 @@ import writePlist from './writePlist';
  * Unlinks assets from iOS project. Removes references for fonts from `Info.plist`
  * fonts provided by application and from `Resources` group
  */
-module.exports = function unlinkAssetsIOS(files, projectConfig) {
+export default function unlinkAssetsIOS(files, projectConfig) {
   const project = xcode.project(projectConfig.pbxprojPath).parseSync();
   const assets = groupFilesByType(files);
   const plist = getPlist(project, projectConfig.sourceDir);
@@ -58,4 +58,4 @@ module.exports = function unlinkAssetsIOS(files, projectConfig) {
   fs.writeFileSync(projectConfig.pbxprojPath, project.writeSync());
 
   writePlist(project, projectConfig.sourceDir, plist);
-};
+}

--- a/packages/cli/src/link/ios/unregisterNativeModule.js
+++ b/packages/cli/src/link/ios/unregisterNativeModule.js
@@ -27,7 +27,7 @@ import removeSharedLibraries from './removeSharedLibraries';
  *
  * If library is already unlinked, this action is a no-op.
  */
-module.exports = function unregisterNativeModule(
+export default function unregisterNativeModule(
   dependencyConfig,
   projectConfig,
   iOSDependencies
@@ -71,4 +71,4 @@ module.exports = function unregisterNativeModule(
   }
 
   fs.writeFileSync(projectConfig.pbxprojPath, project.writeSync());
-};
+}

--- a/packages/cli/src/link/ios/writePlist.js
+++ b/packages/cli/src/link/ios/writePlist.js
@@ -16,7 +16,7 @@ import getPlistPath from './getPlistPath';
  *
  * Returns `null` if INFOPLIST_FILE is not specified or file is non-existent.
  */
-module.exports = function writePlist(project, sourceDir, plist) {
+export default function writePlist(project, sourceDir, plist) {
   const plistPath = getPlistPath(project, sourceDir);
 
   if (!plistPath) {
@@ -30,4 +30,4 @@ module.exports = function writePlist(project, sourceDir, plist) {
     plistPath,
     `${plistParser.build(plist, { indent: '\t', offset: -1 })}\n`
   );
-};
+}

--- a/packages/cli/src/link/link.js
+++ b/packages/cli/src/link/link.js
@@ -12,7 +12,7 @@ import { pick } from 'lodash';
 import type { ContextT } from '../core/types.flow';
 
 import promiseWaterfall from './promiseWaterfall';
-import log from '../util/logger';
+import { error } from '../util/logger';
 import getDependencyConfig from './getDependencyConfig';
 import commandStub from './commandStub';
 import promisify from './promisify';
@@ -43,7 +43,7 @@ function link([rawPackageName]: Array<string>, ctx: ContextT, opts: FlagsType) {
     }
     project = getProjectConfig(ctx, platforms);
   } catch (err) {
-    log.error('No package found. Are you sure this is a React Native project?');
+    error('No package found. Are you sure this is a React Native project?');
     return Promise.reject(err);
   }
   const hasProjectConfig = Object.keys(platforms).reduce(
@@ -77,7 +77,7 @@ function link([rawPackageName]: Array<string>, ctx: ContextT, opts: FlagsType) {
   ];
 
   return promiseWaterfall(tasks).catch(err => {
-    log.error(
+    error(
       `Something went wrong while linking. Error: ${err.message} \n` +
         'Please file an issue here: https://github.com/facebook/react-native/issues'
     );

--- a/packages/cli/src/link/link.js
+++ b/packages/cli/src/link/link.js
@@ -12,7 +12,7 @@ import { pick } from 'lodash';
 import type { ContextT } from '../core/types.flow';
 
 import promiseWaterfall from './promiseWaterfall';
-import { error } from '../util/logger';
+import log from '../util/logger';
 import getDependencyConfig from './getDependencyConfig';
 import commandStub from './commandStub';
 import promisify from './promisify';
@@ -43,7 +43,7 @@ function link([rawPackageName]: Array<string>, ctx: ContextT, opts: FlagsType) {
     }
     project = getProjectConfig(ctx, platforms);
   } catch (err) {
-    error('No package found. Are you sure this is a React Native project?');
+    log.error('No package found. Are you sure this is a React Native project?');
     return Promise.reject(err);
   }
   const hasProjectConfig = Object.keys(platforms).reduce(
@@ -77,7 +77,7 @@ function link([rawPackageName]: Array<string>, ctx: ContextT, opts: FlagsType) {
   ];
 
   return promiseWaterfall(tasks).catch(err => {
-    error(
+    log.error(
       `Something went wrong while linking. Error: ${err.message} \n` +
         'Please file an issue here: https://github.com/facebook/react-native/issues'
     );

--- a/packages/cli/src/link/link.js
+++ b/packages/cli/src/link/link.js
@@ -85,7 +85,9 @@ function link([rawPackageName]: Array<string>, ctx: ContextT, opts: FlagsType) {
   });
 }
 
-module.exports = {
+export const func = link;
+
+export default {
   func: link,
   description: 'scope link command to certain platforms (comma-separated)',
   name: 'link [packageName]',
@@ -98,3 +100,5 @@ module.exports = {
     },
   ],
 };
+
+// link;

--- a/packages/cli/src/link/linkAll.js
+++ b/packages/cli/src/link/linkAll.js
@@ -57,4 +57,4 @@ function linkAll(
   });
 }
 
-module.exports = linkAll;
+export default linkAll;

--- a/packages/cli/src/link/linkAssets.js
+++ b/packages/cli/src/link/linkAssets.js
@@ -32,4 +32,4 @@ const linkAssets = (
   log.info('Assets have been successfully linked to your project');
 };
 
-module.exports = linkAssets;
+export default linkAssets;

--- a/packages/cli/src/link/linkDependency.js
+++ b/packages/cli/src/link/linkDependency.js
@@ -22,6 +22,7 @@ const linkDependency = async (
       platforms[platform] &&
       platforms[platform].linkConfig &&
       platforms[platform].linkConfig();
+
     if (!linkConfig || !linkConfig.isInstalled || !linkConfig.register) {
       return;
     }
@@ -60,4 +61,4 @@ const linkDependency = async (
   });
 };
 
-module.exports = linkDependency;
+export default linkDependency;

--- a/packages/cli/src/link/pods/addPodEntry.js
+++ b/packages/cli/src/link/pods/addPodEntry.js
@@ -7,7 +7,7 @@
  * @format
  */
 
-module.exports = function addPodEntry(
+export default function addPodEntry(
   podLines,
   linesToAddEntry,
   podName,
@@ -27,7 +27,7 @@ module.exports = function addPodEntry(
     const { line, indentation } = linesToAddEntry;
     podLines.splice(line, 0, getLineToAdd(newEntry, indentation));
   }
-};
+}
 
 function getLineToAdd(newEntry, indentation) {
   const spaces = Array(indentation + 1).join(' ');

--- a/packages/cli/src/link/pods/findLineToAddPod.js
+++ b/packages/cli/src/link/pods/findLineToAddPod.js
@@ -7,7 +7,7 @@
  * @format
  */
 
-module.exports = function findLineToAddPod(podLines, firstTargetLine) {
+export default function findLineToAddPod(podLines, firstTargetLine) {
   // match line with new target: target 'project_name' do (most likely target inside podfile main target)
   const nextTarget = /target ('|")\w+('|") do/g;
   // match line that has only 'end' (if we don't catch new target or function, this would mean this is end of current target)
@@ -29,4 +29,4 @@ module.exports = function findLineToAddPod(podLines, firstTargetLine) {
     }
   }
   return null;
-};
+}

--- a/packages/cli/src/link/pods/findMarkedLinesInPodfile.js
+++ b/packages/cli/src/link/pods/findMarkedLinesInPodfile.js
@@ -9,7 +9,7 @@
 
 const MARKER_TEXT = '# Add new pods below this line';
 
-module.exports = function findMarkedLinesInPodfile(podLines) {
+export default function findMarkedLinesInPodfile(podLines) {
   const result = [];
   for (let i = 0, len = podLines.length; i < len; i++) {
     if (podLines[i].includes(MARKER_TEXT)) {
@@ -17,4 +17,4 @@ module.exports = function findMarkedLinesInPodfile(podLines) {
     }
   }
   return result;
-};
+}

--- a/packages/cli/src/link/pods/findPodTargetLine.js
+++ b/packages/cli/src/link/pods/findPodTargetLine.js
@@ -7,7 +7,7 @@
  * @format
  */
 
-module.exports = function findPodTargetLine(podLines, projectName) {
+export default function findPodTargetLine(podLines, projectName) {
   const targetName = projectName.replace('.xcodeproj', '');
   // match first target definition in file: target 'target_name' do
   const targetRegex = new RegExp(`target ('|")${targetName}('|") do`, 'g');
@@ -18,4 +18,4 @@ module.exports = function findPodTargetLine(podLines, projectName) {
     }
   }
   return null;
-};
+}

--- a/packages/cli/src/link/pods/isInstalled.js
+++ b/packages/cli/src/link/pods/isInstalled.js
@@ -9,7 +9,7 @@
 
 import readPodfile from './readPodfile';
 
-module.exports = function isInstalled(iOSProject, dependencyConfig) {
+export default function isInstalled(iOSProject, dependencyConfig) {
   if (!iOSProject.podfile) {
     return false;
   }
@@ -26,4 +26,4 @@ module.exports = function isInstalled(iOSProject, dependencyConfig) {
     }
   }
   return false;
-};
+}

--- a/packages/cli/src/link/pods/readPodfile.js
+++ b/packages/cli/src/link/pods/readPodfile.js
@@ -9,7 +9,7 @@
 
 import fs from 'fs';
 
-module.exports = function readPodfile(podfilePath) {
+export default function readPodfile(podfilePath) {
   const podContent = fs.readFileSync(podfilePath, 'utf8');
   return podContent.split(/\r?\n/g);
-};
+}

--- a/packages/cli/src/link/pods/registerNativeModule.js
+++ b/packages/cli/src/link/pods/registerNativeModule.js
@@ -14,7 +14,7 @@ import findMarkedLinesInPodfile from './findMarkedLinesInPodfile';
 import addPodEntry from './addPodEntry';
 import savePodFile from './savePodFile';
 
-module.exports = function registerNativeModulePods(
+export default function registerNativeModulePods(
   name,
   dependencyConfig,
   iOSProject
@@ -23,7 +23,7 @@ module.exports = function registerNativeModulePods(
   const linesToAddEntry = getLinesToAddEntry(podLines, iOSProject);
   addPodEntry(podLines, linesToAddEntry, dependencyConfig.podspec, name);
   savePodFile(iOSProject.podfile, podLines);
-};
+}
 
 function getLinesToAddEntry(podLines, { projectName }) {
   const linesToAddPodWithMarker = findMarkedLinesInPodfile(podLines);

--- a/packages/cli/src/link/pods/removePodEntry.js
+++ b/packages/cli/src/link/pods/removePodEntry.js
@@ -7,11 +7,11 @@
  * @format
  */
 
-module.exports = function removePodEntry(podfileContent, podName) {
+export default function removePodEntry(podfileContent, podName) {
   // this regex should catch line(s) with full pod definition, like: pod 'podname', :path => '../node_modules/podname', :subspecs => ['Sub2', 'Sub1']
   const podRegex = new RegExp(
     `\\n( |\\t)*pod\\s+("|')${podName}("|')(,\\s*(:[a-z]+\\s*=>)?\\s*(("|').*?("|')|\\[[\\s\\S]*?\\]))*\\n`,
     'g'
   );
   return podfileContent.replace(podRegex, '\n');
-};
+}

--- a/packages/cli/src/link/pods/savePodFile.js
+++ b/packages/cli/src/link/pods/savePodFile.js
@@ -9,7 +9,7 @@
 
 import fs from 'fs';
 
-module.exports = function savePodFile(podfilePath, podLines) {
+export default function savePodFile(podfilePath, podLines) {
   const newPodfile = podLines.join('\n');
   fs.writeFileSync(podfilePath, newPodfile);
-};
+}

--- a/packages/cli/src/link/pods/unregisterNativeModule.js
+++ b/packages/cli/src/link/pods/unregisterNativeModule.js
@@ -13,8 +13,8 @@ import removePodEntry from './removePodEntry';
 /**
  * Unregister native module IOS with CocoaPods
  */
-module.exports = function unregisterNativeModule(dependencyConfig, iOSProject) {
+export default function unregisterNativeModule(dependencyConfig, iOSProject) {
   const podContent = fs.readFileSync(iOSProject.podfile, 'utf8');
   const removed = removePodEntry(podContent, dependencyConfig.podspec);
   fs.writeFileSync(iOSProject.podfile, removed);
-};
+}

--- a/packages/cli/src/link/pollParams.js
+++ b/packages/cli/src/link/pollParams.js
@@ -9,7 +9,7 @@
 
 import inquirer from 'inquirer';
 
-module.exports = questions =>
+export default questions =>
   new Promise((resolve, reject) => {
     if (!questions) {
       resolve({});

--- a/packages/cli/src/link/promiseWaterfall.js
+++ b/packages/cli/src/link/promiseWaterfall.js
@@ -15,9 +15,9 @@
  *
  * Returns the value last promise from a sequence resolved
  */
-module.exports = function promiseWaterfall(tasks) {
+export default function promiseWaterfall(tasks) {
   return tasks.reduce(
     (prevTaskPromise, task) => prevTaskPromise.then(task),
     Promise.resolve()
   );
-};
+}

--- a/packages/cli/src/link/promisify.js
+++ b/packages/cli/src/link/promisify.js
@@ -7,7 +7,7 @@
  * @format
  */
 
-module.exports = func =>
+export default func =>
   new Promise((resolve, reject) =>
     func((err, res) => (err ? reject(err) : resolve(res)))
   );

--- a/packages/cli/src/link/unlink.js
+++ b/packages/cli/src/link/unlink.js
@@ -36,6 +36,7 @@ const unlinkDependency = (
       platforms[platform] &&
       platforms[platform].linkConfig &&
       platforms[platform].linkConfig();
+
     if (!linkConfig || !linkConfig.isInstalled || !linkConfig.unregister) {
       return;
     }
@@ -164,7 +165,7 @@ function unlink(args: Array<string>, ctx: ContextT) {
     });
 }
 
-module.exports = {
+export default {
   func: unlink,
   description: 'unlink native dependency',
   name: 'unlink <packageName>',

--- a/packages/cli/src/logAndroid/logAndroid.js
+++ b/packages/cli/src/logAndroid/logAndroid.js
@@ -27,7 +27,7 @@ async function logAndroid() {
   }
 }
 
-module.exports = {
+export default {
   name: 'log-android',
   description: 'starts adb logcat',
   func: logAndroid,

--- a/packages/cli/src/logIOS/logIOS.js
+++ b/packages/cli/src/logIOS/logIOS.js
@@ -63,7 +63,7 @@ function tailDeviceLogs(udid) {
   }
 }
 
-module.exports = {
+export default {
   name: 'log-ios',
   description: 'starts iOS device syslog tail',
   func: logIOS,

--- a/packages/cli/src/runAndroid/__tests__/runOnAllDevices.test.js
+++ b/packages/cli/src/runAndroid/__tests__/runOnAllDevices.test.js
@@ -6,6 +6,8 @@
  *
  */
 
+import runOnAllDevices from '../runOnAllDevices';
+
 jest.mock('child_process', () => ({
   execFileSync: jest.fn(),
   spawnSync: jest.fn(),
@@ -13,8 +15,6 @@ jest.mock('child_process', () => ({
 
 jest.mock('../getAdbPath');
 const { execFileSync } = require('child_process');
-
-import runOnAllDevices from '../runOnAllDevices';
 
 describe('--appFolder', () => {
   beforeEach(() => {

--- a/packages/cli/src/runAndroid/__tests__/runOnAllDevices.test.js
+++ b/packages/cli/src/runAndroid/__tests__/runOnAllDevices.test.js
@@ -14,7 +14,7 @@ jest.mock('child_process', () => ({
 jest.mock('../getAdbPath');
 const { execFileSync } = require('child_process');
 
-const runOnAllDevices = require('../runOnAllDevices');
+import runOnAllDevices from '../runOnAllDevices';
 
 describe('--appFolder', () => {
   beforeEach(() => {

--- a/packages/cli/src/runAndroid/adb.js
+++ b/packages/cli/src/runAndroid/adb.js
@@ -43,7 +43,7 @@ function getDevices(): Array<string> {
   }
 }
 
-module.exports = {
+export default {
   parseDevicesResult,
   getDevices,
 };

--- a/packages/cli/src/runAndroid/adb.js
+++ b/packages/cli/src/runAndroid/adb.js
@@ -48,4 +48,4 @@ export default {
   getDevices,
 };
 
-export { parseDevicesResult, getDevices };
+// export { parseDevicesResult, getDevices };

--- a/packages/cli/src/runAndroid/adb.js
+++ b/packages/cli/src/runAndroid/adb.js
@@ -47,3 +47,5 @@ export default {
   parseDevicesResult,
   getDevices,
 };
+
+export { parseDevicesResult, getDevices };

--- a/packages/cli/src/runAndroid/getAdbPath.js
+++ b/packages/cli/src/runAndroid/getAdbPath.js
@@ -13,4 +13,4 @@ function getAdbPath() {
     : 'adb';
 }
 
-module.exports = getAdbPath;
+export default getAdbPath;

--- a/packages/cli/src/runAndroid/runAndroid.js
+++ b/packages/cli/src/runAndroid/runAndroid.js
@@ -32,6 +32,7 @@ function checkAndroid(root) {
 /**
  * Starts the app on a connected Android emulator or device.
  */
+// eslint-disable-next-line flowtype/no-weak-types
 function runAndroid(argv: Array<string>, ctx: ContextT, args: Object) {
   if (!checkAndroid(args.root)) {
     logger.error(
@@ -225,6 +226,7 @@ function startServerInNewWindow(
    */
   const scriptsDir = path.dirname(launchPackagerScript);
   const packagerEnvFile = path.join(scriptsDir, packagerEnvFilename);
+  // eslint-disable-next-line flowtype/no-weak-types
   const procConfig: Object = { cwd: scriptsDir };
 
   /**

--- a/packages/cli/src/runAndroid/runAndroid.js
+++ b/packages/cli/src/runAndroid/runAndroid.js
@@ -264,7 +264,7 @@ function startServerInNewWindow(
   );
 }
 
-module.exports = {
+export default {
   name: 'run-android',
   description:
     'builds your app and starts it on a connected Android emulator or device',

--- a/packages/cli/src/runAndroid/runOnAllDevices.js
+++ b/packages/cli/src/runAndroid/runOnAllDevices.js
@@ -108,4 +108,4 @@ function runOnAllDevices(
   }
 }
 
-module.exports = runOnAllDevices;
+export default runOnAllDevices;

--- a/packages/cli/src/runAndroid/runOnAllDevices.js
+++ b/packages/cli/src/runAndroid/runOnAllDevices.js
@@ -20,6 +20,7 @@ function getCommand(appFolder, command) {
 }
 
 function runOnAllDevices(
+  // eslint-disable-next-line flowtype/no-weak-types
   args: Object,
   cmd: string,
   packageNameWithSuffix: string,

--- a/packages/cli/src/runAndroid/tryLaunchAppOnDevice.js
+++ b/packages/cli/src/runAndroid/tryLaunchAppOnDevice.js
@@ -36,4 +36,4 @@ function tryLaunchAppOnDevice(
   }
 }
 
-module.exports = tryLaunchAppOnDevice;
+export default tryLaunchAppOnDevice;

--- a/packages/cli/src/runAndroid/tryRunAdbReverse.js
+++ b/packages/cli/src/runAndroid/tryRunAdbReverse.js
@@ -32,4 +32,4 @@ function tryRunAdbReverse(packagerPort: number | string, device: string) {
   }
 }
 
-module.exports = tryRunAdbReverse;
+export default tryRunAdbReverse;

--- a/packages/cli/src/runIOS/__tests__/findMatchingSimulator-test.js
+++ b/packages/cli/src/runIOS/__tests__/findMatchingSimulator-test.js
@@ -11,7 +11,7 @@
 
 jest.dontMock('../findMatchingSimulator');
 
-const findMatchingSimulator = require('../findMatchingSimulator');
+import findMatchingSimulator from '../findMatchingSimulator';
 
 describe('findMatchingSimulator', () => {
   it('should find simulator', () => {

--- a/packages/cli/src/runIOS/__tests__/findMatchingSimulator-test.js
+++ b/packages/cli/src/runIOS/__tests__/findMatchingSimulator-test.js
@@ -9,9 +9,9 @@
  * @emails oncall+javascript_foundation
  */
 
-jest.dontMock('../findMatchingSimulator');
-
 import findMatchingSimulator from '../findMatchingSimulator';
+
+jest.dontMock('../findMatchingSimulator');
 
 describe('findMatchingSimulator', () => {
   it('should find simulator', () => {

--- a/packages/cli/src/runIOS/__tests__/findXcodeProject-test.js
+++ b/packages/cli/src/runIOS/__tests__/findXcodeProject-test.js
@@ -8,9 +8,9 @@
  * @emails oncall+javascript_foundation
  */
 
-jest.dontMock('../findXcodeProject');
-
 import findXcodeProject from '../findXcodeProject';
+
+jest.dontMock('../findXcodeProject');
 
 describe('findXcodeProject', () => {
   it('should find *.xcodeproj file', () => {

--- a/packages/cli/src/runIOS/__tests__/findXcodeProject-test.js
+++ b/packages/cli/src/runIOS/__tests__/findXcodeProject-test.js
@@ -10,7 +10,7 @@
 
 jest.dontMock('../findXcodeProject');
 
-const findXcodeProject = require('../findXcodeProject');
+import findXcodeProject from '../findXcodeProject';
 
 describe('findXcodeProject', () => {
   it('should find *.xcodeproj file', () => {

--- a/packages/cli/src/runIOS/__tests__/parseIOSDevicesList-test.js
+++ b/packages/cli/src/runIOS/__tests__/parseIOSDevicesList-test.js
@@ -9,7 +9,7 @@
  */
 
 jest.dontMock('../parseIOSDevicesList');
-const parseIOSDevicesList = require('../parseIOSDevicesList');
+import parseIOSDevicesList from '../parseIOSDevicesList';
 
 describe('parseIOSDevicesList', () => {
   it('parses typical output', () => {

--- a/packages/cli/src/runIOS/__tests__/parseIOSDevicesList-test.js
+++ b/packages/cli/src/runIOS/__tests__/parseIOSDevicesList-test.js
@@ -8,8 +8,9 @@
  * @emails oncall+javascript_foundation
  */
 
-jest.dontMock('../parseIOSDevicesList');
 import parseIOSDevicesList from '../parseIOSDevicesList';
+
+jest.dontMock('../parseIOSDevicesList');
 
 describe('parseIOSDevicesList', () => {
   it('parses typical output', () => {

--- a/packages/cli/src/runIOS/findMatchingSimulator.js
+++ b/packages/cli/src/runIOS/findMatchingSimulator.js
@@ -98,4 +98,4 @@ function findMatchingSimulator(simulators, simulatorString) {
   return null;
 }
 
-module.exports = findMatchingSimulator;
+export default findMatchingSimulator;

--- a/packages/cli/src/runIOS/findXcodeProject.js
+++ b/packages/cli/src/runIOS/findXcodeProject.js
@@ -38,4 +38,4 @@ function findXcodeProject(files: Array<string>): ?ProjectInfo {
   return null;
 }
 
-module.exports = findXcodeProject;
+export default findXcodeProject;

--- a/packages/cli/src/runIOS/parseIOSDevicesList.js
+++ b/packages/cli/src/runIOS/parseIOSDevicesList.js
@@ -33,4 +33,4 @@ function parseIOSDevicesList(text: string): Array<IOSDeviceInfo> {
   return devices;
 }
 
-module.exports = parseIOSDevicesList;
+export default parseIOSDevicesList;

--- a/packages/cli/src/runIOS/runIOS.js
+++ b/packages/cli/src/runIOS/runIOS.js
@@ -430,7 +430,7 @@ function getProcessOptions(launchPackager, port) {
   };
 }
 
-module.exports = {
+export default {
   name: 'run-ios',
   description: 'builds your app and starts it on iOS simulator',
   func: runIOS,

--- a/packages/cli/src/server/middleware/MiddlewareManager.js
+++ b/packages/cli/src/server/middleware/MiddlewareManager.js
@@ -36,7 +36,7 @@ type WebSocketProxy = {
 
 type Connect = $Call<connect>;
 
-module.exports = class MiddlewareManager {
+export default class MiddlewareManager {
   app: Connect;
 
   options: Options;
@@ -71,4 +71,4 @@ module.exports = class MiddlewareManager {
       getDevToolsMiddleware(this.options, () => socket.isChromeConnected())
     );
   }
-};
+}

--- a/packages/cli/src/server/middleware/copyToClipBoardMiddleware.js
+++ b/packages/cli/src/server/middleware/copyToClipBoardMiddleware.js
@@ -14,7 +14,7 @@ import logger from '../../util/logger';
  * Handle the request from JS to copy contents onto host system clipboard.
  * This is only supported on Mac for now.
  */
-module.exports = function copyMiddleware(req, res, next) {
+export default function copyMiddleware(req, res, next) {
   if (req.url === '/copy-to-clipboard') {
     const ret = copyToClipBoard(req.rawBody);
     if (!ret) {
@@ -24,4 +24,4 @@ module.exports = function copyMiddleware(req, res, next) {
   } else {
     next();
   }
-};
+}

--- a/packages/cli/src/server/middleware/getDevToolsMiddleware.js
+++ b/packages/cli/src/server/middleware/getDevToolsMiddleware.js
@@ -26,7 +26,7 @@ function launchDevTools({ host, port, watchFolders }, isChromeConnected) {
   }
 }
 
-module.exports = function getDevToolsMiddleware(options, isChromeConnected) {
+export default function getDevToolsMiddleware(options, isChromeConnected) {
   return function devToolsMiddleware(req, res, next) {
     if (req.url === '/launch-safari-devtools') {
       // TODO: remove `logger.info` and dev tools binary
@@ -51,4 +51,4 @@ module.exports = function getDevToolsMiddleware(options, isChromeConnected) {
       next();
     }
   };
-};
+}

--- a/packages/cli/src/server/middleware/getSecurityHeadersMiddleware.js
+++ b/packages/cli/src/server/middleware/getSecurityHeadersMiddleware.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-module.exports = function getSecurityHeadersMiddleware(req, res, next) {
+export default function getSecurityHeadersMiddleware(req, res, next) {
   const address = req.client.server.address();
 
   // Block any cross origin request.
@@ -24,4 +24,4 @@ module.exports = function getSecurityHeadersMiddleware(req, res, next) {
   res.setHeader('X-Content-Type-Options', 'nosniff');
 
   next();
-};
+}

--- a/packages/cli/src/server/middleware/indexPage.js
+++ b/packages/cli/src/server/middleware/indexPage.js
@@ -10,10 +10,10 @@
 import fs from 'fs';
 import path from 'path';
 
-module.exports = function indexPageMiddleware(req, res, next) {
+export default function indexPageMiddleware(req, res, next) {
   if (req.url === '/') {
     res.end(fs.readFileSync(path.join(__dirname, 'index.html')));
   } else {
     next();
   }
-};
+}

--- a/packages/cli/src/server/middleware/loadRawBodyMiddleware.js
+++ b/packages/cli/src/server/middleware/loadRawBodyMiddleware.js
@@ -7,7 +7,7 @@
  * @format
  */
 
-module.exports = function rawBodyMiddleware(req, res, next) {
+export default function rawBodyMiddleware(req, res, next) {
   req.rawBody = '';
   req.setEncoding('utf8');
 
@@ -18,4 +18,4 @@ module.exports = function rawBodyMiddleware(req, res, next) {
   req.on('end', () => {
     next();
   });
-};
+}

--- a/packages/cli/src/server/middleware/openStackFrameInEditorMiddleware.js
+++ b/packages/cli/src/server/middleware/openStackFrameInEditorMiddleware.js
@@ -9,9 +9,7 @@
 
 import launchEditor from '../util/launchEditor';
 
-module.exports = function getOpenStackFrameInEditorMiddleware({
-  watchFolders,
-}) {
+export default function getOpenStackFrameInEditorMiddleware({ watchFolders }) {
   return (req, res, next) => {
     if (req.url === '/open-stack-frame') {
       const frame = JSON.parse(req.rawBody);
@@ -21,4 +19,4 @@ module.exports = function getOpenStackFrameInEditorMiddleware({
       next();
     }
   };
-};
+}

--- a/packages/cli/src/server/middleware/statusPageMiddleware.js
+++ b/packages/cli/src/server/middleware/statusPageMiddleware.js
@@ -11,10 +11,10 @@
  * Status page so that anyone who needs to can verify that the packager is
  * running on 8081 and not another program / service.
  */
-module.exports = function statusPageMiddleware(req, res, next) {
+export default function statusPageMiddleware(req, res, next) {
   if (req.url === '/status') {
     res.end('packager-status:running');
   } else {
     next();
   }
-};
+}

--- a/packages/cli/src/server/middleware/systraceProfileMiddleware.js
+++ b/packages/cli/src/server/middleware/systraceProfileMiddleware.js
@@ -10,7 +10,7 @@
 import fs from 'fs';
 import logger from '../../util/logger';
 
-module.exports = function systraceProfileMiddleware(req, res, next) {
+export default function systraceProfileMiddleware(req, res, next) {
   if (req.url !== '/systrace') {
     next();
     return;
@@ -26,4 +26,4 @@ module.exports = function systraceProfileMiddleware(req, res, next) {
     `This message is also printed to your console by the packager so you can copy it :)`;
   logger.info(response);
   res.end(response);
-};
+}

--- a/packages/cli/src/server/middleware/unless.js
+++ b/packages/cli/src/server/middleware/unless.js
@@ -7,7 +7,7 @@
  * @format
  */
 
-module.exports = (url, middleware) => (req, res, next) => {
+export default (url, middleware) => (req, res, next) => {
   if (req.url === url || req.url.startsWith(`${url}/`)) {
     middleware(req, res, next);
   } else {

--- a/packages/cli/src/server/runServer.js
+++ b/packages/cli/src/server/runServer.js
@@ -119,4 +119,4 @@ function getReporterImpl(customLogReporterPath: ?string) {
   }
 }
 
-module.exports = runServer;
+export default runServer;

--- a/packages/cli/src/server/server.js
+++ b/packages/cli/src/server/server.js
@@ -9,10 +9,11 @@
  */
 
 import path from 'path';
+import runServer from './runServer';
 
 export default {
   name: 'start',
-  func: require('./runServer'),
+  func: runServer,
   description: 'starts the webserver',
   options: [
     {

--- a/packages/cli/src/server/server.js
+++ b/packages/cli/src/server/server.js
@@ -10,7 +10,7 @@
 
 import path from 'path';
 
-module.exports = {
+export default {
   name: 'start',
   func: require('./runServer'),
   description: 'starts the webserver',

--- a/packages/cli/src/server/util/copyToClipBoard.js
+++ b/packages/cli/src/server/util/copyToClipBoard.js
@@ -40,4 +40,4 @@ function copyToClipBoard(content) {
   }
 }
 
-module.exports = copyToClipBoard;
+export default copyToClipBoard;

--- a/packages/cli/src/server/util/jsPackagerClient.js
+++ b/packages/cli/src/server/util/jsPackagerClient.js
@@ -118,4 +118,4 @@ class JsPackagerClient {
   }
 }
 
-module.exports = JsPackagerClient;
+export default JsPackagerClient;

--- a/packages/cli/src/server/util/launchChrome.js
+++ b/packages/cli/src/server/util/launchChrome.js
@@ -55,4 +55,4 @@ function launchChrome(url: string) {
   });
 }
 
-module.exports = launchChrome;
+export default launchChrome;

--- a/packages/cli/src/server/util/launchEditor.js
+++ b/packages/cli/src/server/util/launchEditor.js
@@ -235,4 +235,4 @@ function launchEditor(fileName, lineNumber, projectRoots) {
   });
 }
 
-module.exports = launchEditor;
+export default launchEditor;

--- a/packages/cli/src/server/util/webSocketProxy.js
+++ b/packages/cli/src/server/util/webSocketProxy.js
@@ -7,7 +7,7 @@
  * @format
  */
 
-const logger = require('../../util/logger');
+import logger from '../../util/logger';
 
 function attachToServer(server, path) {
   const WebSocketServer = require('ws').Server;

--- a/packages/cli/src/server/util/webSocketProxy.js
+++ b/packages/cli/src/server/util/webSocketProxy.js
@@ -80,6 +80,6 @@ function attachToServer(server, path) {
   };
 }
 
-module.exports = {
+export default {
   attachToServer,
 };

--- a/packages/cli/src/upgrade/upgrade.js
+++ b/packages/cli/src/upgrade/upgrade.js
@@ -151,4 +151,4 @@ const upgradeCommand = {
   func: validateAndUpgrade,
 };
 
-module.exports = upgradeCommand;
+export default upgradeCommand;

--- a/packages/cli/src/util/PackageManager.js
+++ b/packages/cli/src/util/PackageManager.js
@@ -48,4 +48,3 @@ export default class PackageManager {
       : this.executeCommand(`npm uninstall ${packageNames.join(' ')} --save`);
   }
 }
-

--- a/packages/cli/src/util/PackageManager.js
+++ b/packages/cli/src/util/PackageManager.js
@@ -48,3 +48,4 @@ export default class PackageManager {
       : this.executeCommand(`npm uninstall ${packageNames.join(' ')} --save`);
   }
 }
+

--- a/packages/cli/src/util/PackageManager.js
+++ b/packages/cli/src/util/PackageManager.js
@@ -71,7 +71,7 @@ function remove(packageName, projectDir) {
   );
 }
 
-module.exports = {
+export default {
   add,
   remove,
 };

--- a/packages/cli/src/util/__tests__/findSymlinkedModules-test.js
+++ b/packages/cli/src/util/__tests__/findSymlinkedModules-test.js
@@ -8,11 +8,12 @@
  * @emails oncall+javascript_foundation
  */
 
+import findSymlinkedModules from '../findSymlinkedModules';
+
 jest.mock('path');
 jest.mock('fs');
 
 const fs = require('fs');
-import findSymlinkedModules from '../findSymlinkedModules';
 
 describe('findSymlinksForProjectRoot', () => {
   it('correctly finds normal module symlinks', () => {

--- a/packages/cli/src/util/__tests__/findSymlinkedModules-test.js
+++ b/packages/cli/src/util/__tests__/findSymlinkedModules-test.js
@@ -12,7 +12,7 @@ jest.mock('path');
 jest.mock('fs');
 
 const fs = require('fs');
-const findSymlinkedModules = require('../findSymlinkedModules');
+import findSymlinkedModules from '../findSymlinkedModules';
 
 describe('findSymlinksForProjectRoot', () => {
   it('correctly finds normal module symlinks', () => {

--- a/packages/cli/src/util/assertRequiredOptions.js
+++ b/packages/cli/src/util/assertRequiredOptions.js
@@ -13,7 +13,7 @@ import { camelCase } from 'lodash';
 // Commander.js has a 2 years old open issue to support <...> syntax
 // for options. Until that gets merged, we run the checks manually
 // https://github.com/tj/commander.js/issues/230
-module.exports = function assertRequiredOptions(options, passedOptions) {
+export default function assertRequiredOptions(options, passedOptions) {
   options.forEach(opt => {
     const option = new Option(opt.command);
 
@@ -28,4 +28,4 @@ module.exports = function assertRequiredOptions(options, passedOptions) {
       throw new Error(`error: option '${option.long}' missing`);
     }
   });
-};
+}

--- a/packages/cli/src/util/copyAndReplace.js
+++ b/packages/cli/src/util/copyAndReplace.js
@@ -131,4 +131,4 @@ function copyBinaryFile(srcPath, destPath, cb) {
   }
 }
 
-module.exports = copyAndReplace;
+export default copyAndReplace;

--- a/packages/cli/src/util/findReactNativeScripts.js
+++ b/packages/cli/src/util/findReactNativeScripts.js
@@ -23,4 +23,4 @@ function findReactNativeScripts(): ?string {
   return null;
 }
 
-module.exports = findReactNativeScripts;
+export default findReactNativeScripts;

--- a/packages/cli/src/util/findSymlinkedModules.js
+++ b/packages/cli/src/util/findSymlinkedModules.js
@@ -30,7 +30,7 @@ import fs from 'fs';
  * The end result should be a list of all resolved module symlinks for a given
  * root.
  */
-module.exports = function findSymlinkedModules(
+export default function findSymlinkedModules(
   projectRoot: string,
   ignoredRoots?: Array<string> = []
 ) {
@@ -40,7 +40,7 @@ module.exports = function findSymlinkedModules(
     projectRoot,
   ]);
   return resolvedSymlinks;
-};
+}
 
 function findModuleSymlinks(
   modulesPath: string,

--- a/packages/cli/src/util/isInstalledGlobally.js
+++ b/packages/cli/src/util/isInstalledGlobally.js
@@ -7,12 +7,13 @@
  * @format
  */
 
+import fs from 'fs';
+import path from 'path';
+
 const isWindows = process.platform === 'win32';
 
 export default function isInstalledGlobally() {
   if (isWindows) {
-    const fs = require('fs');
-    const path = require('path');
     // On Windows, assume we are installed globally if we can't find a
     // package.json above node_modules.
     return !fs.existsSync(path.join(__dirname, '../../../package.json'));

--- a/packages/cli/src/util/isInstalledGlobally.js
+++ b/packages/cli/src/util/isInstalledGlobally.js
@@ -9,7 +9,7 @@
 
 const isWindows = process.platform === 'win32';
 
-module.exports = function isInstalledGlobally() {
+export default function isInstalledGlobally() {
   if (isWindows) {
     const fs = require('fs');
     const path = require('path');
@@ -21,4 +21,4 @@ module.exports = function isInstalledGlobally() {
   // outside of the node_mobules/.bin/react-native executable.
   const script = process.argv[1];
   return script.indexOf('node_modules/.bin/react-native') === -1;
-};
+}

--- a/packages/cli/src/util/isPackagerRunning.js
+++ b/packages/cli/src/util/isPackagerRunning.js
@@ -30,4 +30,4 @@ function isPackagerRunning(packagerPort = process.env.RCT_METRO_PORT || 8081) {
   );
 }
 
-module.exports = isPackagerRunning;
+export default isPackagerRunning;

--- a/packages/cli/src/util/isValidPackageName.js
+++ b/packages/cli/src/util/isValidPackageName.js
@@ -11,4 +11,4 @@ function isValidPackageName(name) {
   return name.match(/^[$A-Z_][0-9A-Z_$]*$/i);
 }
 
-module.exports = isValidPackageName;
+export default isValidPackageName;

--- a/packages/cli/src/util/loadMetroConfig.js
+++ b/packages/cli/src/util/loadMetroConfig.js
@@ -84,7 +84,7 @@ export type ConfigOptionsT = {
  *
  * This allows the CLI to always overwrite the file settings.
  */
-module.exports = async function load(
+export default async function load(
   ctx: ContextT,
   options?: ConfigOptionsT = {}
 ): Promise<ConfigT> {
@@ -99,4 +99,4 @@ module.exports = async function load(
   );
 
   return config;
-};
+}

--- a/packages/cli/src/util/logger.js
+++ b/packages/cli/src/util/logger.js
@@ -36,4 +36,4 @@ export default {
   debug,
 };
 
-export { info, warn, error, debug };
+// export { info, warn, error, debug };

--- a/packages/cli/src/util/logger.js
+++ b/packages/cli/src/util/logger.js
@@ -35,3 +35,5 @@ export default {
   error,
   debug,
 };
+
+export { info, warn, error, debug };

--- a/packages/cli/src/util/logger.js
+++ b/packages/cli/src/util/logger.js
@@ -29,7 +29,7 @@ const debug = (...messages: Array<string>) => {
   console.log(`${chalk.black.bgWhite(' DEBUG ')} ${joinMessages(messages)}`);
 };
 
-module.exports = {
+export default {
   info,
   warn,
   error,

--- a/packages/cli/src/util/walk.js
+++ b/packages/cli/src/util/walk.js
@@ -21,4 +21,4 @@ function walk(current) {
   return [].concat.apply([current], files);
 }
 
-module.exports = walk;
+export default walk;

--- a/packages/cli/src/util/yarn.js
+++ b/packages/cli/src/util/yarn.js
@@ -52,7 +52,7 @@ function isGlobalCliUsingYarn(projectDir) {
   return fs.existsSync(path.join(projectDir, 'yarn.lock'));
 }
 
-module.exports = {
+export default {
   getYarnVersionIfAvailable,
   isGlobalCliUsingYarn,
 };


### PR DESCRIPTION
This is an extra for #150 
Fixes exports and tweaks some tests.

The `link`, `linkAssets`, and `linkDependency` where trickier as hell, but we have all tests working.

I suggest take it easy in this review as I'm worried in a "false positive" in tests as there was a LOT of changes.

We need to improve the code coverage for changes like this have smaller chances of failing...