### PR TITLE
feat(perf): use lazy module evaluation

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -10,5 +10,11 @@ module.exports = {
     ],
     require.resolve('@babel/preset-flow'),
   ],
-  plugins: [require.resolve('@babel/plugin-transform-strict-mode')],
+  plugins: [
+    require.resolve('@babel/plugin-transform-strict-mode'),
+    [
+      require.resolve('@babel/plugin-transform-modules-commonjs'),
+      { lazy: true },
+    ],
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.0.0",
+    "@babel/plugin-transform-modules-commonjs": "^7.2.0",
     "@babel/plugin-transform-strict-mode": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-flow": "^7.0.0",


### PR DESCRIPTION
Summary:
---------

After #150 (thanks @sidferreira and @Trancever) we're finally able to use lazy module evaluation for additional perf! 

Before:
```
0.70 real         0.64 user         0.12 sys
```
After:
```
0.19 real         0.16 user         0.03 sys
```

Which gives us roughly 0.5s (~72%) improvement in startup time. With 0.2s startup time most commands feel instant now.

Test Plan:
----------

No new tests added.
