### PR TITLE
Esemesek/fix init pgkes

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/cli",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "React Native CLI",
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/cli",
-  "version": "1.1.0",
+  "version": "1.0.1",
   "description": "React Native CLI",
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/cli/src/init/init.js
+++ b/packages/cli/src/init/init.js
@@ -68,6 +68,7 @@ function generateProject(destinationRoot, newProjectName, options) {
     return;
   }
 
+  // TODO: Use `PackageManager` in generator to remove `yarn` calls.
   const yarnVersion =
     !options.npm &&
     yarn.getYarnVersionIfAvailable() &&
@@ -85,22 +86,18 @@ function generateProject(destinationRoot, newProjectName, options) {
     yarnVersion
   );
 
-  const DEPENDENCIES = [`react@${reactVersion}`];
+  logger.info('Adding required dependencies');
+  packageManager.install([`react@${reactVersion}`]);
 
-  const DEV_DEPENDENCIES = [
+  logger.info('Adding required dev dependencies');
+  packageManager.installDev([
     '@babel/core',
     '@babel/runtime',
     'jest',
     'babel-jest',
     'metro-react-native-babel-preset',
     `react-test-renderer@${reactVersion}`,
-  ];
-
-  logger.info('Adding required dependencies');
-  packageManager.install(DEPENDENCIES);
-
-  logger.info('Adding required dev dependencies');
-  packageManager.installDev(DEV_DEPENDENCIES);
+  ]);
 
   addJestToPackageJson(destinationRoot);
   printRunInstructions(destinationRoot, newProjectName);

--- a/packages/cli/src/install/install.js
+++ b/packages/cli/src/install/install.js
@@ -19,7 +19,7 @@ const spawnOpts = {
 function install(args, ctx) {
   const name = args[0];
 
-  let res = PackageManager.add(name, ctx.root);
+  let res = new PackageManager({ projectDir: ctx.root }).install([name]);
 
   if (res.status) {
     process.exit(res.status);

--- a/packages/cli/src/install/install.js
+++ b/packages/cli/src/install/install.js
@@ -19,13 +19,13 @@ const spawnOpts = {
 function install(args, ctx) {
   const name = args[0];
 
-  let res = new PackageManager({ projectDir: ctx.root }).install([name]);
-
-  if (res.status) {
-    process.exit(res.status);
+  try {
+    new PackageManager({ projectDir: ctx.root }).install([name]);
+  } catch (e) {
+    process.exit(e.status);
   }
 
-  res = spawnSync('react-native', ['link', name], spawnOpts);
+  const res = spawnSync('react-native', ['link', name], spawnOpts);
 
   if (res.status) {
     process.exit(res.status);

--- a/packages/cli/src/install/install.js
+++ b/packages/cli/src/install/install.js
@@ -16,14 +16,10 @@ const spawnOpts = {
   stdin: 'inherit',
 };
 
-function install(args, ctx) {
+async function install(args, ctx) {
   const name = args[0];
 
-  try {
-    new PackageManager({ projectDir: ctx.root }).install([name]);
-  } catch (e) {
-    process.exit(e.status);
-  }
+  new PackageManager({ projectDir: ctx.root }).install([name]);
 
   const res = spawnSync('react-native', ['link', name], spawnOpts);
 

--- a/packages/cli/src/install/uninstall.js
+++ b/packages/cli/src/install/uninstall.js
@@ -25,7 +25,7 @@ function uninstall(args, ctx) {
     process.exit(res.status);
   }
 
-  res = new PackageManager({ projectDir: ctx.root }).uninstall(name);
+  res = new PackageManager({ projectDir: ctx.root }).uninstall([name]);
 
   if (res.status) {
     process.exit(res.status);

--- a/packages/cli/src/install/uninstall.js
+++ b/packages/cli/src/install/uninstall.js
@@ -25,7 +25,7 @@ function uninstall(args, ctx) {
     process.exit(res.status);
   }
 
-  res = PackageManager.remove(name, ctx.root);
+  res = new PackageManager({ projectDir: ctx.root }).uninstall(name);
 
   if (res.status) {
     process.exit(res.status);

--- a/packages/cli/src/install/uninstall.js
+++ b/packages/cli/src/install/uninstall.js
@@ -16,7 +16,7 @@ const spawnOpts = {
   stdin: 'inherit',
 };
 
-function uninstall(args, ctx) {
+async function uninstall(args, ctx) {
   const name = args[0];
 
   const res = spawnSync('react-native', ['unlink', name], spawnOpts);
@@ -25,11 +25,7 @@ function uninstall(args, ctx) {
     process.exit(res.status);
   }
 
-  try {
-    new PackageManager({ projectDir: ctx.root }).uninstall([name]);
-  } catch (e) {
-    process.exit(e.status);
-  }
+  new PackageManager({ projectDir: ctx.root }).uninstall([name]);
 
   logger.info(`Module ${name} has been successfully uninstalled & unlinked`);
 }

--- a/packages/cli/src/install/uninstall.js
+++ b/packages/cli/src/install/uninstall.js
@@ -19,16 +19,16 @@ const spawnOpts = {
 function uninstall(args, ctx) {
   const name = args[0];
 
-  let res = spawnSync('react-native', ['unlink', name], spawnOpts);
+  const res = spawnSync('react-native', ['unlink', name], spawnOpts);
 
   if (res.status) {
     process.exit(res.status);
   }
 
-  res = new PackageManager({ projectDir: ctx.root }).uninstall([name]);
-
-  if (res.status) {
-    process.exit(res.status);
+  try {
+    new PackageManager({ projectDir: ctx.root }).uninstall([name]);
+  } catch (e) {
+    process.exit(e.status);
   }
 
   logger.info(`Module ${name} has been successfully uninstalled & unlinked`);

--- a/packages/cli/src/util/PackageManager.js
+++ b/packages/cli/src/util/PackageManager.js
@@ -46,11 +46,11 @@ export default class PackageManager {
     }
   }
 
-  uninstall(packageName: string) {
+  uninstall(packageNames: Array<string>) {
     if (this.shouldCallYarn()) {
-      this.executeCommand(`yarn remove ${packageName}`);
+      this.executeCommand(`yarn remove ${packageNames.join(' ')}`);
     } else {
-      this.executeCommand(`npm uninstall ${packageName} --save`);
+      this.executeCommand(`npm uninstall ${packageNames.join(' ')} --save`);
     }
   }
 }

--- a/packages/cli/src/util/PackageManager.js
+++ b/packages/cli/src/util/PackageManager.js
@@ -27,30 +27,24 @@ export default class PackageManager {
   }
 
   install(packageNames: Array<string>) {
-    if (this.shouldCallYarn()) {
-      this.executeCommand(`yarn add ${packageNames.join(' ')}`);
-    } else {
-      this.executeCommand(
-        `npm install ${packageNames.join(' ')} --save --save-exact`
-      );
-    }
+    return this.shouldCallYarn()
+      ? this.executeCommand(`yarn add ${packageNames.join(' ')}`)
+      : this.executeCommand(
+          `npm install ${packageNames.join(' ')} --save --save-exact`
+        );
   }
 
   installDev(packageNames: Array<string>) {
-    if (this.shouldCallYarn()) {
-      this.executeCommand(`yarn add -D ${packageNames.join(' ')}`);
-    } else {
-      this.executeCommand(
-        `npm install ${packageNames.join(' ')} --save-dev --save-exact`
-      );
-    }
+    return this.shouldCallYarn()
+      ? this.executeCommand(`yarn add -D ${packageNames.join(' ')}`)
+      : this.executeCommand(
+          `npm install ${packageNames.join(' ')} --save-dev --save-exact`
+        );
   }
 
   uninstall(packageNames: Array<string>) {
-    if (this.shouldCallYarn()) {
-      this.executeCommand(`yarn remove ${packageNames.join(' ')}`);
-    } else {
-      this.executeCommand(`npm uninstall ${packageNames.join(' ')} --save`);
-    }
+    return this.shouldCallYarn()
+      ? this.executeCommand(`yarn remove ${packageNames.join(' ')}`)
+      : this.executeCommand(`npm uninstall ${packageNames.join(' ')} --save`);
   }
 }

--- a/packages/cli/src/util/PackageManager.js
+++ b/packages/cli/src/util/PackageManager.js
@@ -1,77 +1,56 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- * @format
- */
+// @flow
+import { execSync } from 'child_process';
+import yarn from './yarn';
 
-const { spawnSync } = require('child_process');
-const yarn = require('../util/yarn');
-
-const spawnOpts = {
-  stdio: 'inherit',
-  stdin: 'inherit',
+type PackageManagerOptions = {
+  forceNpm?: boolean,
+  projectDir: string,
 };
 
-/**
- * Execute npm or yarn command
- *
- * @param  {String} yarnCommand Yarn command to be executed eg. yarn add package
- * @param  {String} npmCommand  Npm command to be executed eg. npm install package
- * @param  {string} projectDir  Directory to run the command in
- * @return {object}             spawnSync's result object
- */
-function callYarnOrNpm(yarnCommand, npmCommand, projectDir) {
-  let command;
+export default class PackageManager {
+  options: PackageManagerOptions;
 
-  const isYarnAvailable =
-    yarn.getYarnVersionIfAvailable() && yarn.isGlobalCliUsingYarn(projectDir);
-
-  if (isYarnAvailable) {
-    command = yarnCommand;
-  } else {
-    command = npmCommand;
+  constructor(options: PackageManagerOptions) {
+    this.options = options;
   }
 
-  const args = command.split(' ');
-  const cmd = args.shift();
+  executeCommand(command: string) {
+    return execSync(command, { stdio: 'inherit' });
+  }
 
-  const res = spawnSync(cmd, args, spawnOpts);
+  shouldCallYarn() {
+    return (
+      !this.options.forceNpm &&
+      yarn.getYarnVersionIfAvailable() &&
+      yarn.isGlobalCliUsingYarn(this.options.projectDir)
+    );
+  }
 
-  return res;
+  install(packageNames: Array<string>) {
+    if (this.shouldCallYarn()) {
+      this.executeCommand(`yarn add ${packageNames.join(' ')}`);
+    } else {
+      this.executeCommand(
+        `npm install ${packageNames.join(' ')} --save --save-exact`
+      );
+    }
+  }
+
+  installDev(packageNames: Array<string>) {
+    if (this.shouldCallYarn()) {
+      this.executeCommand(`yarn add -D ${packageNames.join(' ')}`);
+    } else {
+      this.executeCommand(
+        `npm install ${packageNames.join(' ')} --save-dev --save-exact`
+      );
+    }
+  }
+
+  uninstall(packageName: string) {
+    if (this.shouldCallYarn()) {
+      this.executeCommand(`yarn remove ${packageName}`);
+    } else {
+      this.executeCommand(`npm uninstall ${packageName} --save`);
+    }
+  }
 }
-
-/**
- * Install package into project using npm or yarn if available
- * @param  {[type]} packageName Package to be installed
- * @param  {string} projectDir  Root directory of the project
- * @return {[type]}             spawnSync's result object
- */
-function add(packageName, projectDir) {
-  return callYarnOrNpm(
-    `yarn add ${packageName}`,
-    `npm install ${packageName} --save`,
-    projectDir
-  );
-}
-
-/**
- * Uninstall package from project using npm or yarn if available
- * @param  {[type]} packageName Package to be uninstalled
- * @param  {string} projectDir  Root directory of the project
- * @return {Object}             spawnSync's result object
- */
-function remove(packageName, projectDir) {
-  return callYarnOrNpm(
-    `yarn remove ${packageName}`,
-    `npm uninstall --save ${packageName}`,
-    projectDir
-  );
-}
-
-module.exports = {
-  add,
-  remove,
-};

--- a/packages/cli/src/util/__tests__/PackageManager-test.js
+++ b/packages/cli/src/util/__tests__/PackageManager-test.js
@@ -5,7 +5,6 @@ import yarn from '../yarn';
 
 const PROJECT_DIR = '/project/directory';
 const PACKAGES = ['react', 'react-native'];
-const PACKAGE = '@babel/core';
 const EXEC_OPTS = { stdio: 'inherit' };
 
 beforeEach(() => {
@@ -21,9 +20,9 @@ describe('yarn', () => {
   });
 
   it('should install', () => {
-    const uut = new PackageManager({ projectDir: PROJECT_DIR });
+    const packageManager = new PackageManager({ projectDir: PROJECT_DIR });
 
-    uut.install(PACKAGES);
+    packageManager.install(PACKAGES);
 
     expect(ChildProcess.execSync).toHaveBeenCalledWith(
       'yarn add react react-native',
@@ -32,9 +31,9 @@ describe('yarn', () => {
   });
 
   it('should installDev', () => {
-    const uut = new PackageManager({ projectDir: PROJECT_DIR });
+    const packageManager = new PackageManager({ projectDir: PROJECT_DIR });
 
-    uut.installDev(PACKAGES);
+    packageManager.installDev(PACKAGES);
 
     expect(ChildProcess.execSync).toHaveBeenCalledWith(
       'yarn add -D react react-native',
@@ -43,12 +42,12 @@ describe('yarn', () => {
   });
 
   it('should uninstall', () => {
-    const uut = new PackageManager({ projectDir: PROJECT_DIR });
+    const packageManager = new PackageManager({ projectDir: PROJECT_DIR });
 
-    uut.uninstall(PACKAGE);
+    packageManager.uninstall(PACKAGES);
 
     expect(ChildProcess.execSync).toHaveBeenCalledWith(
-      `yarn remove ${PACKAGE}`,
+      `yarn remove react react-native`,
       EXEC_OPTS
     );
   });
@@ -56,9 +55,12 @@ describe('yarn', () => {
 
 describe('npm', () => {
   it('should install', () => {
-    const uut = new PackageManager({ projectDir: PROJECT_DIR, forceNpm: true });
+    const packageManager = new PackageManager({
+      projectDir: PROJECT_DIR,
+      forceNpm: true,
+    });
 
-    uut.install(PACKAGES);
+    packageManager.install(PACKAGES);
 
     expect(ChildProcess.execSync).toHaveBeenCalledWith(
       'npm install react react-native --save --save-exact',
@@ -67,9 +69,12 @@ describe('npm', () => {
   });
 
   it('should installDev', () => {
-    const uut = new PackageManager({ projectDir: PROJECT_DIR, forceNpm: true });
+    const packageManager = new PackageManager({
+      projectDir: PROJECT_DIR,
+      forceNpm: true,
+    });
 
-    uut.installDev(PACKAGES);
+    packageManager.installDev(PACKAGES);
 
     expect(ChildProcess.execSync).toHaveBeenCalledWith(
       'npm install react react-native --save-dev --save-exact',
@@ -78,12 +83,15 @@ describe('npm', () => {
   });
 
   it('should uninstall', () => {
-    const uut = new PackageManager({ projectDir: PROJECT_DIR, forceNpm: true });
+    const packageManager = new PackageManager({
+      projectDir: PROJECT_DIR,
+      forceNpm: true,
+    });
 
-    uut.uninstall(PACKAGE);
+    packageManager.uninstall(PACKAGES);
 
     expect(ChildProcess.execSync).toHaveBeenCalledWith(
-      `npm uninstall ${PACKAGE} --save`,
+      `npm uninstall react react-native --save`,
       EXEC_OPTS
     );
   });
@@ -91,9 +99,9 @@ describe('npm', () => {
 
 it('should use npm if yarn is not available', () => {
   jest.spyOn(yarn, 'getYarnVersionIfAvailable').mockImplementation(() => false);
-  const uut = new PackageManager({ projectDir: PROJECT_DIR });
+  const packageManager = new PackageManager({ projectDir: PROJECT_DIR });
 
-  uut.install(PACKAGES);
+  packageManager.install(PACKAGES);
 
   expect(ChildProcess.execSync).toHaveBeenCalledWith(
     `npm install react react-native --save --save-exact`,
@@ -103,9 +111,9 @@ it('should use npm if yarn is not available', () => {
 
 it('should use npm if global cli is not using yarn', () => {
   jest.spyOn(yarn, 'isGlobalCliUsingYarn').mockImplementation(() => false);
-  const uut = new PackageManager({ projectDir: PROJECT_DIR });
+  const packageManager = new PackageManager({ projectDir: PROJECT_DIR });
 
-  uut.install(PACKAGES);
+  packageManager.install(PACKAGES);
 
   expect(ChildProcess.execSync).toHaveBeenCalledWith(
     `npm install react react-native --save --save-exact`,

--- a/packages/cli/src/util/__tests__/PackageManager-test.js
+++ b/packages/cli/src/util/__tests__/PackageManager-test.js
@@ -1,0 +1,114 @@
+// @flow
+import ChildProcess from 'child_process';
+import PackageManager from '../PackageManager';
+import yarn from '../yarn';
+
+const PROJECT_DIR = '/project/directory';
+const PACKAGES = ['react', 'react-native'];
+const PACKAGE = '@babel/core';
+const EXEC_OPTS = { stdio: 'inherit' };
+
+beforeEach(() => {
+  jest.spyOn(ChildProcess, 'execSync').mockImplementation(() => {});
+});
+
+describe('yarn', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(yarn, 'getYarnVersionIfAvailable')
+      .mockImplementation(() => true);
+    jest.spyOn(yarn, 'isGlobalCliUsingYarn').mockImplementation(() => true);
+  });
+
+  it('should install', () => {
+    const uut = new PackageManager({ projectDir: PROJECT_DIR });
+
+    uut.install(PACKAGES);
+
+    expect(ChildProcess.execSync).toHaveBeenCalledWith(
+      'yarn add react react-native',
+      EXEC_OPTS
+    );
+  });
+
+  it('should installDev', () => {
+    const uut = new PackageManager({ projectDir: PROJECT_DIR });
+
+    uut.installDev(PACKAGES);
+
+    expect(ChildProcess.execSync).toHaveBeenCalledWith(
+      'yarn add -D react react-native',
+      EXEC_OPTS
+    );
+  });
+
+  it('should uninstall', () => {
+    const uut = new PackageManager({ projectDir: PROJECT_DIR });
+
+    uut.uninstall(PACKAGE);
+
+    expect(ChildProcess.execSync).toHaveBeenCalledWith(
+      `yarn remove ${PACKAGE}`,
+      EXEC_OPTS
+    );
+  });
+});
+
+describe('npm', () => {
+  it('should install', () => {
+    const uut = new PackageManager({ projectDir: PROJECT_DIR, forceNpm: true });
+
+    uut.install(PACKAGES);
+
+    expect(ChildProcess.execSync).toHaveBeenCalledWith(
+      'npm install react react-native --save --save-exact',
+      EXEC_OPTS
+    );
+  });
+
+  it('should installDev', () => {
+    const uut = new PackageManager({ projectDir: PROJECT_DIR, forceNpm: true });
+
+    uut.installDev(PACKAGES);
+
+    expect(ChildProcess.execSync).toHaveBeenCalledWith(
+      'npm install react react-native --save-dev --save-exact',
+      EXEC_OPTS
+    );
+  });
+
+  it('should uninstall', () => {
+    const uut = new PackageManager({ projectDir: PROJECT_DIR, forceNpm: true });
+
+    uut.uninstall(PACKAGE);
+
+    expect(ChildProcess.execSync).toHaveBeenCalledWith(
+      `npm uninstall ${PACKAGE} --save`,
+      EXEC_OPTS
+    );
+  });
+});
+
+it('should use npm if yarn is not available', () => {
+  jest.spyOn(yarn, 'getYarnVersionIfAvailable').mockImplementation(() => false);
+  const uut = new PackageManager({ projectDir: PROJECT_DIR });
+
+  uut.install(PACKAGES);
+
+  expect(ChildProcess.execSync).toHaveBeenCalledWith(
+    `npm install react react-native --save --save-exact`,
+    EXEC_OPTS
+  );
+});
+
+it('should use npm if global cli is not using yarn', () => {
+  jest.spyOn(yarn, 'isGlobalCliUsingYarn').mockImplementation(() => false);
+  const uut = new PackageManager({ projectDir: PROJECT_DIR });
+
+  uut.install(PACKAGES);
+
+  expect(ChildProcess.execSync).toHaveBeenCalledWith(
+    `npm install react react-native --save --save-exact`,
+    EXEC_OPTS
+  );
+});


### PR DESCRIPTION
Summary:
---------
- [x] - Added `PackageManager` to use throughout the application to install packages. Replaced usage in `install` and `uninstall` commands, but we should probably handle installing packages the same way everywhere
- [x] - Removed option to not include `jest` in deps. We will have upgraded template support in the future. I think we don't need this additional complexity here, and I don't know anyone who wouldn't install `jest` in a fresh project.


Test Plan:
----------

Added unit tests and tested in an existing project.
