### PR TITLE
refactor: disable logger in tests

### DIFF
--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  setupFiles: ['./testSetup.js'],
+  testEnvironment: 'node',
+};

--- a/packages/cli/src/util/logger.js
+++ b/packages/cli/src/util/logger.js
@@ -3,6 +3,18 @@
  */
 import chalk from 'chalk';
 
+// eslint-disable-next-line no-unused-vars
+const noop = (...msgs: Array<string>) => {};
+
+const shouldLogMessages = () => process.env.NODE_ENV !== 'test';
+
+const LOGGER_STUB = {
+  info: noop,
+  warn: noop,
+  error: noop,
+  debug: noop,
+};
+
 const SEPARATOR = ', ';
 
 const joinMessages = (messages: Array<string>) => messages.join(SEPARATOR);
@@ -29,9 +41,11 @@ const debug = (...messages: Array<string>) => {
   console.log(`${chalk.black.bgWhite(' DEBUG ')} ${joinMessages(messages)}`);
 };
 
-module.exports = {
-  info,
-  warn,
-  error,
-  debug,
-};
+module.exports = shouldLogMessages()
+  ? {
+      info,
+      warn,
+      error,
+      debug,
+    }
+  : LOGGER_STUB;

--- a/packages/cli/src/util/logger.js
+++ b/packages/cli/src/util/logger.js
@@ -3,18 +3,6 @@
  */
 import chalk from 'chalk';
 
-// eslint-disable-next-line no-unused-vars
-const noop = (...msgs: Array<string>) => {};
-
-const shouldLogMessages = () => process.env.NODE_ENV !== 'test';
-
-const LOGGER_STUB = {
-  info: noop,
-  warn: noop,
-  error: noop,
-  debug: noop,
-};
-
 const SEPARATOR = ', ';
 
 const joinMessages = (messages: Array<string>) => messages.join(SEPARATOR);
@@ -41,11 +29,9 @@ const debug = (...messages: Array<string>) => {
   console.log(`${chalk.black.bgWhite(' DEBUG ')} ${joinMessages(messages)}`);
 };
 
-module.exports = shouldLogMessages()
-  ? {
-      info,
-      warn,
-      error,
-      debug,
-    }
-  : LOGGER_STUB;
+module.exports = {
+  info,
+  warn,
+  error,
+  debug,
+};

--- a/packages/cli/testSetup.js
+++ b/packages/cli/testSetup.js
@@ -1,0 +1,7 @@
+// @flow
+jest.mock('./src/util/logger', () => ({
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+}));

--- a/packages/cli/testSetup.js
+++ b/packages/cli/testSetup.js
@@ -1,7 +1,2 @@
 // @flow
-jest.mock('./src/util/logger', () => ({
-  info: () => {},
-  warn: () => {},
-  error: () => {},
-  debug: () => {},
-}));
+jest.mock('./src/util/logger');


### PR DESCRIPTION
Summary:
---------
Disable annoying logs in a `test` environment.

Test Plan:
----------

```
➜  react-native-cli git:(master) ✗ yarn test
yarn run v1.13.0
$ jest
 PASS  packages/cli/src/runIOS/__tests__/findMatchingSimulator-test.js
 PASS  packages/cli/src/util/__tests__/findSymlinkedModules-test.js
 PASS  packages/cli/src/server/util/debugger-ui/__tests__/DeltaPatcher-test.js
 PASS  packages/cli/src/core/__tests__/findPlugins-test.js
 PASS  packages/cli/src/link/__tests__/android/makeSettingsPatch-test.js
 PASS  packages/cli/src/link/__tests__/ios/getHeaderSearchPath-test.js
 PASS  packages/cli/src/core/__tests__/ios/findProject-test.js
 PASS  packages/cli/src/core/__tests__/android/getProjectConfig-test.js
 PASS  packages/cli/src/bundle/__tests__/getAssetDestPathAndroid-test.js
 PASS  packages/cli/src/runAndroid/__tests__/runOnAllDevices.test.js
 PASS  packages/cli/src/link/__tests__/pods/removePodEntry-test.js
 PASS  packages/cli/src/link/__tests__/ios/writePlist-test.js
 PASS  packages/cli/src/link/__tests__/ios/createGroup-test.js
 PASS  packages/cli/src/link/__tests__/pods/findLineToAddPod-test.js
 PASS  packages/cli/src/link/__tests__/android/makeBuildPatch-test.js
 PASS  packages/cli/src/core/__tests__/android/getDependencyConfig-test.js
 PASS  packages/cli/src/link/__tests__/ios/addSharedLibraries-test.js
 PASS  packages/cli/src/core/__tests__/android/findPackageClassName-test.js
 PASS  packages/cli/src/link/__tests__/link-test.js
 PASS  packages/cli/src/link/__tests__/pods/isInstalled-test.js
 PASS  packages/cli/src/core/__tests__/ios/findPodspecName-test.js
 PASS  packages/cli/src/link/__tests__/pods/findMarkedLinesInPodfile-test.js
 PASS  packages/cli/src/link/__tests__/ios/getGroup-test.js
 PASS  packages/cli/src/runIOS/__tests__/findXcodeProject-test.js
 PASS  packages/cli/src/core/__tests__/ios/getProjectConfig-test.js
 PASS  packages/cli/src/runIOS/__tests__/parseIOSDevicesList-test.js
 PASS  packages/cli/src/link/__tests__/ios/removeProjectFromProject-test.js
 PASS  packages/cli/src/link/__tests__/promiseWaterfall-test.js
 PASS  packages/cli/src/link/__tests__/ios/removeSharedLibrary-test.js
 PASS  packages/cli/src/bundle/__tests__/filterPlatformAssetScales-test.js
 PASS  packages/cli/src/link/__tests__/ios/isInstalled-test.js
 PASS  packages/cli/src/link/__tests__/ios/mapHeaderSearchPaths-test.js
 PASS  packages/cli/src/link/__tests__/ios/getHeadersInFolder-test.js
 PASS  packages/cli/src/link/__tests__/ios/removeProjectFromLibraries-test.js
 PASS  packages/cli/src/core/__tests__/android/readManifest-test.js
 PASS  packages/cli/src/link/__tests__/getProjectDependencies-test.js
 PASS  packages/cli/src/link/__tests__/pods/findPodTargetLine-test.js
 PASS  packages/cli/src/core/__tests__/findAssets-test.js
 PASS  packages/cli/src/link/__tests__/android/isInstalled-test.js
 PASS  packages/cli/src/link/__tests__/getDependencyConfig-test.js
 PASS  packages/cli/src/core/__tests__/android/findAndroidAppFolder-test.js
 PASS  packages/cli/src/link/__tests__/android/makePackagePatch-test.js
 PASS  packages/cli/src/bundle/__tests__/getAssetDestPathIOS-test.js
 PASS  packages/cli/src/core/__tests__/makeCommand-test.js
 PASS  packages/cli/src/link/__tests__/ios/hasLibraryImported-test.js
 PASS  packages/cli/src/link/__tests__/ios/addProjectToLibraries-test.js
 PASS  packages/cli/src/link/__tests__/ios/addFileToProject-test.js
 PASS  packages/cli/src/core/__tests__/android/findManifest-test.js
 PASS  packages/cli/src/core/__tests__/ios/findPodfilePath-test.js
 PASS  packages/cli/src/link/__tests__/ios/getTargets-test.js
 PASS  packages/cli/src/link/__tests__/ios/getBuildProperty-test.js
 PASS  packages/cli/src/link/__tests__/android/makeStringsPatch-test.js
 PASS  packages/cli/src/link/__tests__/android/makeImportPatch-test.js
 PASS  packages/cli/src/link/__tests__/ios/getPlist-test.js
 PASS  packages/cli/src/link/__tests__/ios/getPlistPath-test.js
 PASS  packages/cli/src/link/__tests__/groupFilesByType-test.js
 PASS  packages/cli/src/link/__tests__/android/applyPatch-test.js
 PASS  packages/cli/src/link/__tests__/android/normalizeProjectName-test.js

Test Suites: 58 passed, 58 total
Tests:       1 todo, 199 passed, 200 total
Snapshots:   4 passed, 4 total
Time:        8.226s
Ran all test suites.
✨  Done in 9.69s.
```
