### PR TITLE
refactor: use PackageManager and improve init logging

### DIFF
--- a/packages/cli/src/generator/printRunInstructions.js
+++ b/packages/cli/src/generator/printRunInstructions.js
@@ -13,7 +13,7 @@ import chalk from 'chalk';
 import logger from '../util/logger';
 
 function printRunInstructions(projectDir: string, projectName: string) {
-  const absoluteProjectDir = path.resolve(projectDir);
+  const relativeProjectDir = path.relative(process.cwd(), projectDir);
   const xcodeProjectPath = `${path.resolve(
     projectDir,
     'ios',
@@ -26,14 +26,14 @@ function printRunInstructions(projectDir: string, projectName: string) {
 
   logger.log(`
   ${chalk.cyan(`Run instructions for ${chalk.bold('iOS')}`)}:
-    • cd ${absoluteProjectDir} && react-native run-ios
+    • cd ${relativeProjectDir} && react-native run-ios
     - or -
     • Open ${relativeXcodeProjectPath} in Xcode
     • Hit the Run button
 
   ${chalk.green(`Run instructions for ${chalk.bold('Android')}`)}:
     • Have an Android emulator running (quickest way to get started), or a device connected.
-    • cd ${absoluteProjectDir} && react-native run-android
+    • cd ${relativeProjectDir} && react-native run-android
 `);
 }
 

--- a/packages/cli/src/generator/printRunInstructions.js
+++ b/packages/cli/src/generator/printRunInstructions.js
@@ -5,14 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow
  */
 
 import path from 'path';
+import chalk from 'chalk';
 import logger from '../util/logger';
 
-function printRunInstructions(projectDir, projectName) {
+function printRunInstructions(projectDir: string, projectName: string) {
   const absoluteProjectDir = path.resolve(projectDir);
-  // iOS
   const xcodeProjectPath = `${path.resolve(
     projectDir,
     'ios',
@@ -22,17 +23,18 @@ function printRunInstructions(projectDir, projectName) {
     process.cwd(),
     xcodeProjectPath
   );
-  logger.info(`To run your app on iOS:
-    cd ${absoluteProjectDir}
-    react-native run-ios');
+
+  logger.log(`
+  ${chalk.cyan(`Run instructions for ${chalk.bold('iOS')}`)}:
+    • cd ${absoluteProjectDir} && react-native run-ios
     - or -
-    Open ${relativeXcodeProjectPath} in Xcode
-    Hit the Run button
-  // Android
-  To run your app on Android:
-    cd ${absoluteProjectDir}
-    Have an Android emulator running (quickest way to get started), or a device connected
-    react-native run-android`);
+    • Open ${relativeXcodeProjectPath} in Xcode
+    • Hit the Run button
+
+  ${chalk.green(`Run instructions for ${chalk.bold('Android')}`)}:
+    • Have an Android emulator running (quickest way to get started), or a device connected.
+    • cd ${absoluteProjectDir} && react-native run-android
+`);
 }
 
 module.exports = printRunInstructions;

--- a/packages/cli/src/generator/templates.js
+++ b/packages/cli/src/generator/templates.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow
  */
 
 import { execSync } from 'child_process';
@@ -12,6 +13,7 @@ import fs from 'fs';
 import path from 'path';
 import copyProjectTemplateAndReplace from './copyProjectTemplateAndReplace';
 import logger from '../util/logger';
+import PackageManager from '../util/PackageManager';
 
 /**
  * @param destPath Create the new project at this path.
@@ -21,10 +23,10 @@ import logger from '../util/logger';
  *                    yarn is not available. For example '0.18.1'.
  */
 function createProjectFromTemplate(
-  destPath,
-  newProjectName,
-  template,
-  yarnVersion
+  destPath: string,
+  newProjectName: string,
+  template: string,
+  destinationRoot: string
 ) {
   const templatePath = path.dirname(require.resolve('react-native/template'));
   copyProjectTemplateAndReplace(templatePath, destPath, newProjectName);
@@ -42,7 +44,7 @@ function createProjectFromTemplate(
   // This way we don't have to duplicate the native files in every template.
   // If we duplicated them we'd make RN larger and risk that people would
   // forget to maintain all the copies so they would go out of sync.
-  createFromRemoteTemplate(template, destPath, newProjectName, yarnVersion);
+  createFromRemoteTemplate(template, destPath, newProjectName, destinationRoot);
 }
 
 /**
@@ -51,10 +53,10 @@ function createProjectFromTemplate(
  * - git://..., http://..., file://... or any other URL supported by npm
  */
 function createFromRemoteTemplate(
-  template,
-  destPath,
-  newProjectName,
-  yarnVersion
+  template: string,
+  destPath: string,
+  newProjectName: string,
+  destinationRoot: string
 ) {
   let installPackage;
   let templateName;
@@ -70,17 +72,9 @@ function createFromRemoteTemplate(
 
   // Check if the template exists
   logger.info(`Fetching template ${installPackage}...`);
+  const packageManager = new PackageManager({ projectDir: destinationRoot });
   try {
-    if (yarnVersion) {
-      execSync(`yarn add ${installPackage} --ignore-scripts`, {
-        stdio: 'inherit',
-      });
-    } else {
-      execSync(
-        `npm install ${installPackage} --save --save-exact --ignore-scripts`,
-        { stdio: 'inherit' }
-      );
-    }
+    packageManager.install([installPackage]);
     const templatePath = path.resolve('node_modules', templateName);
     copyProjectTemplateAndReplace(templatePath, destPath, newProjectName, {
       // Every template contains a dummy package.json file included
@@ -93,16 +87,12 @@ function createFromRemoteTemplate(
         'devDependencies.json',
       ],
     });
-    installTemplateDependencies(templatePath, yarnVersion);
-    installTemplateDevDependencies(templatePath, yarnVersion);
+    installTemplateDependencies(templatePath, destinationRoot);
+    installTemplateDevDependencies(templatePath, destinationRoot);
   } finally {
     // Clean up the temp files
     try {
-      if (yarnVersion) {
-        execSync(`yarn remove ${templateName} --ignore-scripts`);
-      } else {
-        execSync(`npm uninstall ${templateName} --ignore-scripts`);
-      }
+      packageManager.uninstall([templateName]);
     } catch (err) {
       // Not critical but we still want people to know and report
       // if this the clean up fails.
@@ -114,7 +104,7 @@ function createFromRemoteTemplate(
   }
 }
 
-function installTemplateDependencies(templatePath, yarnVersion) {
+function installTemplateDependencies(templatePath, destinationRoot) {
   // dependencies.json is a special file that lists additional dependencies
   // that are required by this template
   const dependenciesJsonPath = path.resolve(templatePath, 'dependencies.json');
@@ -126,29 +116,23 @@ function installTemplateDependencies(templatePath, yarnVersion) {
 
   let dependencies;
   try {
-    dependencies = JSON.parse(fs.readFileSync(dependenciesJsonPath));
+    dependencies = JSON.parse(fs.readFileSync(dependenciesJsonPath).toString());
   } catch (err) {
     throw new Error(
       `Could not parse the template's dependencies.json: ${err.message}`
     );
   }
-  for (const depName of Object.keys(dependencies)) {
-    const depVersion = dependencies[depName];
-    const depToInstall = `${depName}@${depVersion}`;
-    logger.info(`Adding ${depToInstall}...`);
-    if (yarnVersion) {
-      execSync(`yarn add ${depToInstall}`, { stdio: 'inherit' });
-    } else {
-      execSync(`npm install ${depToInstall} --save --save-exact`, {
-        stdio: 'inherit',
-      });
-    }
-  }
+  const dependenciesToInstall = Object.keys(dependencies).map(
+    depName => `${depName}@${dependencies[depName]}`
+  );
+  new PackageManager({ projectDir: destinationRoot }).install(
+    dependenciesToInstall
+  );
   logger.info("Linking native dependencies into the project's build files...");
   execSync('react-native link', { stdio: 'inherit' });
 }
 
-function installTemplateDevDependencies(templatePath, yarnVersion) {
+function installTemplateDevDependencies(templatePath, destinationRoot) {
   // devDependencies.json is a special file that lists additional develop dependencies
   // that are required by this template
   const devDependenciesJsonPath = path.resolve(
@@ -163,24 +147,21 @@ function installTemplateDevDependencies(templatePath, yarnVersion) {
 
   let dependencies;
   try {
-    dependencies = JSON.parse(fs.readFileSync(devDependenciesJsonPath));
+    dependencies = JSON.parse(
+      fs.readFileSync(devDependenciesJsonPath).toString()
+    );
   } catch (err) {
     throw new Error(
       `Could not parse the template's devDependencies.json: ${err.message}`
     );
   }
-  for (const depName of Object.keys(dependencies)) {
-    const depVersion = dependencies[depName];
-    const depToInstall = `${depName}@${depVersion}`;
-    logger.info(`Adding ${depToInstall}...`);
-    if (yarnVersion) {
-      execSync(`yarn add ${depToInstall} -D`, { stdio: 'inherit' });
-    } else {
-      execSync(`npm install ${depToInstall} --save-dev --save-exact`, {
-        stdio: 'inherit',
-      });
-    }
-  }
+
+  const dependenciesToInstall = Object.keys(dependencies).map(
+    depName => `${depName}@${dependencies[depName]}`
+  );
+  new PackageManager({ projectDir: destinationRoot }).install(
+    dependenciesToInstall
+  );
 }
 
 export { createProjectFromTemplate };

--- a/packages/cli/src/generator/templates.js
+++ b/packages/cli/src/generator/templates.js
@@ -116,7 +116,7 @@ function installTemplateDependencies(templatePath, destinationRoot) {
 
   let dependencies;
   try {
-    dependencies = JSON.parse(fs.readFileSync(dependenciesJsonPath).toString());
+    dependencies = require(dependenciesJsonPath);
   } catch (err) {
     throw new Error(
       `Could not parse the template's dependencies.json: ${err.message}`
@@ -147,9 +147,7 @@ function installTemplateDevDependencies(templatePath, destinationRoot) {
 
   let dependencies;
   try {
-    dependencies = JSON.parse(
-      fs.readFileSync(devDependenciesJsonPath).toString()
-    );
+    dependencies = require(devDependenciesJsonPath);
   } catch (err) {
     throw new Error(
       `Could not parse the template's devDependencies.json: ${err.message}`

--- a/packages/cli/src/init/init.js
+++ b/packages/cli/src/init/init.js
@@ -13,7 +13,6 @@ import path from 'path';
 import process from 'process';
 import printRunInstructions from '../generator/printRunInstructions';
 import { createProjectFromTemplate } from '../generator/templates';
-import yarn from '../util/yarn';
 import logger from '../util/logger';
 import PackageManager from '../util/PackageManager';
 
@@ -68,12 +67,6 @@ function generateProject(destinationRoot, newProjectName, options) {
     return;
   }
 
-  // TODO: Use `PackageManager` in generator to remove `yarn` calls.
-  const yarnVersion =
-    !options.npm &&
-    yarn.getYarnVersionIfAvailable() &&
-    yarn.isGlobalCliUsingYarn(destinationRoot);
-
   const packageManager = new PackageManager({
     projectDir: destinationRoot,
     forceNpm: options.npm,
@@ -83,7 +76,7 @@ function generateProject(destinationRoot, newProjectName, options) {
     destinationRoot,
     newProjectName,
     options.template,
-    yarnVersion
+    destinationRoot
   );
 
   logger.info('Adding required dependencies');

--- a/packages/cli/src/util/logger.js
+++ b/packages/cli/src/util/logger.js
@@ -9,19 +9,19 @@ const formatMessages = (messages: Array<string>) =>
   chalk.reset(messages.join(SEPARATOR));
 
 const info = (...messages: Array<string>) => {
-  console.log(`${chalk.cyan('info')} ${formatMessages(messages)}`);
+  console.log(`${chalk.cyan.bold('info')} ${formatMessages(messages)}`);
 };
 
 const warn = (...messages: Array<string>) => {
-  console.warn(`${chalk.yellow('warn')} ${formatMessages(messages)}`);
+  console.warn(`${chalk.yellow.bold('warn')} ${formatMessages(messages)}`);
 };
 
 const error = (...messages: Array<string>) => {
-  console.error(`${chalk.red('error')} ${formatMessages(messages)}`);
+  console.error(`${chalk.red.bold('error')} ${formatMessages(messages)}`);
 };
 
 const debug = (...messages: Array<string>) => {
-  console.log(`${chalk.gray('debug')} ${formatMessages(messages)}`);
+  console.log(`${chalk.gray.bold('debug')} ${formatMessages(messages)}`);
 };
 
 const log = (...messages: Array<string>) => {

--- a/packages/cli/src/util/logger.js
+++ b/packages/cli/src/util/logger.js
@@ -4,29 +4,47 @@
 import chalk from 'chalk';
 
 const SEPARATOR = ', ';
+const TITLE = '[rn-cli]';
 
 const joinMessages = (messages: Array<string>) => messages.join(SEPARATOR);
 
+const getTimestamp = () => {
+  const date = new Date();
+  return `${date.getHours()}:${date.getMinutes()}:${date.getSeconds()}`;
+};
+
+const getHeader = () => chalk.gray(`${getTimestamp()} ${TITLE}`);
+
 const info = (...messages: Array<string>) => {
   console.log(
-    `${chalk.black.bgCyan(' INFO ')} ${chalk.reset(joinMessages(messages))}`
+    `${getHeader()} ${chalk.cyan('INFO')} ${chalk.reset(
+      joinMessages(messages)
+    )}`
   );
 };
 
 const warn = (...messages: Array<string>) => {
   console.warn(
-    `${chalk.black.bgYellow(' WARN ')} ${chalk.yellow(joinMessages(messages))}`
+    `${getHeader()} ${chalk.yellow('WARN')} ${chalk.yellow(
+      joinMessages(messages)
+    )}`
   );
 };
 
 const error = (...messages: Array<string>) => {
   console.error(
-    `${chalk.black.bgRed(' ERROR ')} ${chalk.red(joinMessages(messages))}`
+    `${getHeader()} ${chalk.red('ERROR')} ${chalk.red(joinMessages(messages))}`
   );
 };
 
 const debug = (...messages: Array<string>) => {
-  console.log(`${chalk.black.bgWhite(' DEBUG ')} ${joinMessages(messages)}`);
+  console.log(
+    `${getHeader()} ${chalk.white('DEBUG')} ${joinMessages(messages)}`
+  );
+};
+
+const log = (...messages: Array<string>) => {
+  console.log(`${joinMessages(messages)}`);
 };
 
 module.exports = {
@@ -34,4 +52,5 @@ module.exports = {
   warn,
   error,
   debug,
+  log,
 };

--- a/packages/cli/src/util/logger.js
+++ b/packages/cli/src/util/logger.js
@@ -8,12 +8,7 @@ const TITLE = '[rn-cli]';
 
 const joinMessages = (messages: Array<string>) => messages.join(SEPARATOR);
 
-const getTimestamp = () => {
-  const date = new Date();
-  return `${date.getHours()}:${date.getMinutes()}:${date.getSeconds()}`;
-};
-
-const getHeader = () => chalk.gray(`${getTimestamp()} ${TITLE}`);
+const getHeader = () => chalk.gray(`${TITLE}`);
 
 const info = (...messages: Array<string>) => {
   console.log(

--- a/packages/cli/src/util/logger.js
+++ b/packages/cli/src/util/logger.js
@@ -4,42 +4,28 @@
 import chalk from 'chalk';
 
 const SEPARATOR = ', ';
-const TITLE = '[rn-cli]';
 
-const joinMessages = (messages: Array<string>) => messages.join(SEPARATOR);
-
-const getHeader = () => chalk.gray(`${TITLE}`);
+const formatMessages = (messages: Array<string>) =>
+  chalk.reset(messages.join(SEPARATOR));
 
 const info = (...messages: Array<string>) => {
-  console.log(
-    `${getHeader()} ${chalk.cyan('INFO')} ${chalk.reset(
-      joinMessages(messages)
-    )}`
-  );
+  console.log(`${chalk.cyan('info')} ${formatMessages(messages)}`);
 };
 
 const warn = (...messages: Array<string>) => {
-  console.warn(
-    `${getHeader()} ${chalk.yellow('WARN')} ${chalk.yellow(
-      joinMessages(messages)
-    )}`
-  );
+  console.warn(`${chalk.yellow('warn')} ${formatMessages(messages)}`);
 };
 
 const error = (...messages: Array<string>) => {
-  console.error(
-    `${getHeader()} ${chalk.red('ERROR')} ${chalk.red(joinMessages(messages))}`
-  );
+  console.error(`${chalk.red('error')} ${formatMessages(messages)}`);
 };
 
 const debug = (...messages: Array<string>) => {
-  console.log(
-    `${getHeader()} ${chalk.white('DEBUG')} ${joinMessages(messages)}`
-  );
+  console.log(`${chalk.gray('debug')} ${formatMessages(messages)}`);
 };
 
 const log = (...messages: Array<string>) => {
-  console.log(`${joinMessages(messages)}`);
+  console.log(`${formatMessages(messages)}`);
 };
 
 module.exports = {


### PR DESCRIPTION
Summary:
---------

- [x] - Improved logging
- [x] - Fixed run instruction logs
- [x] - Use `PackageManager` in `generator`

<img width="657" alt="zrzut ekranu 2019-02-6 o 21 52 34" src="https://user-images.githubusercontent.com/9092510/52372957-c65dc200-2a59-11e9-899f-6d215109125f.png">

<img width="1440" alt="zrzut ekranu 2019-02-6 o 21 52 59" src="https://user-images.githubusercontent.com/9092510/52372962-cbbb0c80-2a59-11e9-9686-044128eeaa5b.png">

Test Plan:
----------

Tested it initializing new project using a custom template.

Here are logs. They are quite lengthy.

<details>

```
➜  projects react-native init xxx --template mobx --version 0.69.0
This will walk you through creating a new React Native project in /Users/kacper/projects/xxx
Using yarn v1.13.0
Installing react-native@0.69.0...
yarn add v1.13.0
info No lockfile found.
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
warning " > react-native@0.69.0" has unmet peer dependency "react@16.6.3".
warning "react-native > @react-native-community/cli@10.0.0" has incorrect peer dependency "react-native@^0.57.0".
warning "react-native > metro-react-native-babel-transformer@0.51.0" has unmet peer dependency "@babel/core@*".
warning "react-native > @react-native-community/cli > metro-react-native-babel-transformer@0.51.1" has unmet peer dependency "@babel/core@*".
[4/4] 🔨  Building fresh packages...
success Saved lockfile.
success Saved 478 new dependencies.
info Direct dependencies
└─ react-native@0.69.0
info All dependencies
├─ @babel/code-frame@7.0.0
├─ @babel/helper-builder-binary-assignment-operator-visitor@7.1.0
├─ @babel/helper-builder-react-jsx@7.3.0
├─ @babel/helper-call-delegate@7.1.0
├─ @babel/helper-create-class-features-plugin@7.3.2
├─ @babel/helper-define-map@7.1.0
├─ @babel/helper-explode-assignable-expression@7.1.0
├─ @babel/helper-hoist-variables@7.0.0
├─ @babel/helper-module-transforms@7.2.2
├─ @babel/helper-remap-async-to-generator@7.1.0
├─ @babel/helper-replace-supers@7.2.3
├─ @babel/helper-wrap-function@7.2.0
├─ @babel/helpers@7.3.1
├─ @babel/highlight@7.0.0
├─ @babel/plugin-external-helpers@7.2.0
├─ @babel/plugin-syntax-class-properties@7.2.0
├─ @babel/plugin-syntax-export-default-from@7.2.0
├─ @babel/plugin-syntax-flow@7.2.0
├─ @babel/plugin-syntax-nullish-coalescing-operator@7.2.0
├─ @babel/plugin-syntax-optional-catch-binding@7.2.0
├─ @babel/plugin-syntax-optional-chaining@7.2.0
├─ @babel/plugin-syntax-typescript@7.2.0
├─ @babel/plugin-transform-async-to-generator@7.2.0
├─ @babel/plugin-transform-block-scoped-functions@7.2.0
├─ @babel/plugin-transform-member-expression-literals@7.2.0
├─ @babel/plugin-transform-object-super@7.2.0
├─ @babel/plugin-transform-property-literals@7.2.0
├─ @babel/register@7.0.0
├─ @babel/runtime@7.3.1
├─ @react-native-community/cli@10.0.0
├─ abbrev@1.1.1
├─ accepts@1.3.5
├─ acorn-globals@4.3.0
├─ acorn-walk@6.1.1
├─ acorn@5.7.3
├─ ajv@6.8.1
├─ ansi-colors@1.1.0
├─ ansi-cyan@0.1.1
├─ ansi-gray@0.1.1
├─ ansi-red@0.1.1
├─ ansi@0.3.1
├─ anymatch@2.0.0
├─ append-transform@1.0.0
├─ aproba@1.2.0
├─ are-we-there-yet@1.1.5
├─ argparse@1.0.10
├─ arr-flatten@1.1.0
├─ array-equal@1.0.0
├─ array-filter@0.0.1
├─ array-map@0.0.0
├─ array-reduce@0.0.0
├─ array-slice@0.2.3
├─ art@0.10.3
├─ asap@2.0.6
├─ asn1@0.2.4
├─ assign-symbols@1.0.0
├─ astral-regex@1.0.0
├─ async@2.6.1
├─ asynckit@0.4.0
├─ atob@2.1.2
├─ aws-sign2@0.7.0
├─ aws4@1.8.0
├─ babel-core@6.26.3
├─ babel-generator@6.26.1
├─ babel-helpers@6.24.1
├─ babel-jest@24.1.0
├─ babel-plugin-jest-hoist@24.1.0
├─ babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0
├─ babel-preset-jest@24.1.0
├─ babel-register@6.26.0
├─ babel-template@6.26.0
├─ babel-traverse@6.26.0
├─ babel-types@6.26.0
├─ balanced-match@1.0.0
├─ base@0.11.2
├─ base64-js@1.3.0
├─ basic-auth@2.0.1
├─ bcrypt-pbkdf@1.0.2
├─ big-integer@1.6.41
├─ bplist-creator@0.0.7
├─ bplist-parser@0.1.1
├─ brace-expansion@1.1.11
├─ braces@2.3.2
├─ browser-process-hrtime@0.1.3
├─ bser@2.0.0
├─ buffer-crc32@0.2.13
├─ bytes@3.0.0
├─ cache-base@1.0.1
├─ caller-callsite@2.0.0
├─ caller-path@2.0.0
├─ capture-exit@1.2.0
├─ caseless@0.12.0
├─ chardet@0.4.2
├─ chownr@1.1.1
├─ ci-info@2.0.0
├─ class-utils@0.3.6
├─ cli-cursor@2.1.0
├─ cli-width@2.2.0
├─ cliui@4.1.0
├─ code-point-at@1.1.0
├─ collection-visit@1.0.0
├─ color-convert@1.9.3
├─ color-name@1.1.3
├─ color-support@1.1.3
├─ combined-stream@1.0.7
├─ commondir@1.0.1
├─ compare-versions@3.4.0
├─ compressible@2.0.15
├─ concat-map@0.0.1
├─ concat-stream@1.6.2
├─ console-control-strings@1.1.0
├─ convert-source-map@1.6.0
├─ copy-descriptor@0.1.1
├─ core-js@2.6.3
├─ core-util-is@1.0.2
├─ cosmiconfig@5.0.7
├─ create-react-class@15.6.3
├─ cross-spawn@5.1.0
├─ cssom@0.3.6
├─ cssstyle@1.1.1
├─ dashdash@1.14.1
├─ data-urls@1.1.0
├─ debug@2.6.9
├─ decode-uri-component@0.2.0
├─ deep-extend@0.6.0
├─ deep-is@0.1.3
├─ default-require-extensions@2.0.0
├─ delayed-stream@1.0.0
├─ delegates@1.0.0
├─ destroy@1.0.4
├─ detect-indent@4.0.0
├─ detect-libc@1.0.3
├─ detect-newline@2.1.0
├─ diff-sequences@24.0.0
├─ diff@3.5.0
├─ dom-walk@0.1.1
├─ domexception@1.0.1
├─ ecc-jsbn@0.1.2
├─ ee-first@1.1.1
├─ encoding@0.1.12
├─ end-of-stream@1.4.1
├─ envinfo@5.12.1
├─ error-ex@1.3.2
├─ es-abstract@1.13.0
├─ es-to-primitive@1.2.0
├─ escodegen@1.11.0
├─ esprima@3.1.3
├─ estraverse@4.2.0
├─ etag@1.8.1
├─ event-target-shim@1.1.1
├─ eventemitter3@3.1.0
├─ expand-brackets@2.1.4
├─ expand-range@1.8.2
├─ expect@24.1.0
├─ extend@3.0.2
├─ external-editor@2.2.0
├─ extglob@2.0.4
├─ extsprintf@1.3.0
├─ fancy-log@1.3.3
├─ fast-deep-equal@2.0.1
├─ fast-levenshtein@2.0.6
├─ fbjs-css-vars@1.0.2
├─ fbjs-scripts@1.0.1
├─ figures@2.0.0
├─ filename-regex@2.0.1
├─ fileset@2.0.3
├─ fill-range@4.0.0
├─ finalhandler@1.1.0
├─ find-cache-dir@1.0.0
├─ for-in@1.0.2
├─ for-own@0.1.5
├─ forever-agent@0.6.1
├─ form-data@2.3.3
├─ fresh@0.5.2
├─ fs-minipass@1.2.5
├─ fs.realpath@1.0.0
├─ fsevents@1.2.7
├─ gauge@1.2.7
├─ get-stream@4.1.0
├─ get-value@2.0.6
├─ getpass@0.1.7
├─ glob-base@0.3.0
├─ glob-parent@2.0.0
├─ glob@7.1.3
├─ global@4.3.2
├─ growly@1.3.0
├─ handlebars@4.0.12
├─ har-schema@2.0.0
├─ har-validator@5.1.3
├─ has-ansi@2.0.0
├─ has-symbols@1.0.0
├─ has-unicode@2.0.1
├─ has-value@1.0.0
├─ has-values@1.0.0
├─ has@1.0.3
├─ home-or-tmp@3.0.0
├─ hosted-git-info@2.7.1
├─ html-encoding-sniffer@1.0.2
├─ http-errors@1.6.3
├─ http-signature@1.2.0
├─ iconv-lite@0.4.24
├─ ignore-walk@3.0.1
├─ image-size@0.6.3
├─ import-fresh@2.0.0
├─ inflight@1.0.6
├─ inherits@2.0.3
├─ ini@1.3.5
├─ invariant@2.2.4
├─ invert-kv@2.0.0
├─ ip-regex@2.1.0
├─ is-accessor-descriptor@1.0.0
├─ is-arrayish@0.2.1
├─ is-data-descriptor@1.0.0
├─ is-date-object@1.0.1
├─ is-descriptor@1.0.2
├─ is-directory@0.3.1
├─ is-dotfile@1.0.3
├─ is-equal-shallow@0.1.3
├─ is-finite@1.0.2
├─ is-fullwidth-code-point@2.0.0
├─ is-generator-fn@2.0.0
├─ is-plain-object@2.0.4
├─ is-posix-bracket@0.1.1
├─ is-primitive@2.0.0
├─ is-promise@2.1.0
├─ is-regex@1.0.4
├─ is-symbol@1.0.2
├─ is-typedarray@1.0.0
├─ is-utf8@0.2.1
├─ is-windows@1.0.2
├─ is-wsl@1.1.0
├─ isarray@1.0.0
├─ isexe@2.0.0
├─ isstream@0.1.2
├─ istanbul-api@2.1.0
├─ istanbul-lib-hook@2.0.3
├─ istanbul-lib-instrument@3.1.0
├─ istanbul-lib-report@2.0.4
├─ istanbul-lib-source-maps@3.0.2
├─ istanbul-reports@2.1.0
├─ jest-changed-files@24.0.0
├─ jest-cli@24.1.0
├─ jest-docblock@24.0.0
├─ jest-each@24.0.0
├─ jest-environment-node@24.0.0
├─ jest-junit@5.2.0
├─ jest-leak-detector@24.0.0
├─ jest-resolve-dependencies@24.1.0
├─ jest-runner@24.1.0
├─ jest-serializer@24.0.0
├─ jest-watcher@24.0.0
├─ jest@24.0.0-alpha.6
├─ js-tokens@4.0.0
├─ js-yaml@3.12.1
├─ jsesc@2.5.2
├─ json-parse-better-errors@1.0.2
├─ json-schema-traverse@0.4.1
├─ json-schema@0.2.3
├─ json-stable-stringify@1.0.1
├─ json-stringify-safe@5.0.1
├─ json5@2.1.0
├─ jsonfile@2.4.0
├─ jsprim@1.4.1
├─ kind-of@3.2.2
├─ klaw@1.3.1
├─ kleur@3.0.1
├─ lcid@2.0.0
├─ left-pad@1.3.0
├─ levn@0.3.0
├─ load-json-file@2.0.0
├─ locate-path@3.0.0
├─ lodash.pad@4.5.1
├─ lodash.padend@4.6.1
├─ lodash.padstart@4.6.1
├─ lodash@4.17.11
├─ lru-cache@4.1.5
├─ makeerror@1.0.11
├─ map-age-cleaner@0.1.3
├─ map-visit@1.0.0
├─ math-random@1.0.4
├─ mem@4.1.0
├─ merge@1.2.1
├─ metro-babel-register@0.51.0
├─ metro-babel7-plugin-react-transform@0.51.1
├─ metro-config@0.51.1
├─ metro-memory-fs@0.51.1
├─ metro-minify-uglify@0.51.1
├─ metro-react-native-babel-transformer@0.51.0
├─ metro-source-map@0.51.1
├─ metro@0.51.1
├─ mime-db@1.37.0
├─ mime-types@2.1.21
├─ min-document@2.19.0
├─ minimatch@3.0.4
├─ minimist@1.2.0
├─ minizlib@1.2.1
├─ mixin-deep@1.3.1
├─ mkdirp@0.5.1
├─ mute-stream@0.0.7
├─ nan@2.12.1
├─ nanomatch@1.2.13
├─ needle@2.2.4
├─ negotiator@0.6.1
├─ nice-try@1.0.5
├─ node-int64@0.4.0
├─ node-modules-regexp@1.0.0
├─ node-pre-gyp@0.10.3
├─ nopt@4.0.1
├─ normalize-path@2.1.1
├─ npm-bundled@1.0.6
├─ npm-packlist@1.3.0
├─ npmlog@2.0.4
├─ nwsapi@2.1.0
├─ oauth-sign@0.9.0
├─ object-assign@4.1.1
├─ object-copy@0.1.0
├─ object.getownpropertydescriptors@2.0.3
├─ object.omit@2.0.1
├─ onetime@2.0.1
├─ optionator@0.8.2
├─ options@0.0.6
├─ os-homedir@1.0.2
├─ os-locale@3.1.0
├─ os-tmpdir@1.0.2
├─ osenv@0.1.5
├─ p-defer@1.0.0
├─ p-each-series@1.0.0
├─ p-is-promise@2.0.0
├─ p-limit@2.1.0
├─ p-locate@3.0.0
├─ p-reduce@1.0.0
├─ p-try@2.0.0
├─ parse-glob@3.0.4
├─ parse-node-version@1.0.1
├─ parse5@4.0.0
├─ pascalcase@0.1.1
├─ path-is-absolute@1.0.1
├─ path-key@2.0.1
├─ path-parse@1.0.6
├─ path-type@2.0.0
├─ performance-now@2.1.0
├─ pinkie@2.0.4
├─ pkg-dir@3.0.0
├─ plist@3.0.1
├─ plugin-error@0.1.2
├─ pn@1.1.0
├─ posix-character-classes@0.1.1
├─ preserve@0.2.0
├─ private@0.1.8
├─ process-nextick-args@2.0.0
├─ process@0.5.2
├─ prompts@2.0.1
├─ prop-types@15.6.2
├─ pseudomap@1.0.2
├─ pump@3.0.0
├─ qs@6.5.2
├─ randomatic@3.1.1
├─ range-parser@1.2.0
├─ rc@1.2.8
├─ react-clone-referenced-element@1.1.0
├─ react-deep-force-update@1.1.2
├─ react-devtools-core@3.6.0
├─ react-native@0.69.0
├─ react-proxy@1.1.8
├─ read-pkg-up@2.0.0
├─ read-pkg@2.0.0
├─ readable-stream@2.3.6
├─ regenerate-unicode-properties@7.0.0
├─ regenerator-transform@0.13.3
├─ regex-cache@0.4.4
├─ regex-not@1.0.2
├─ regexpu-core@4.4.0
├─ regjsgen@0.5.0
├─ regjsparser@0.6.0
├─ remove-trailing-separator@1.1.0
├─ repeating@2.0.1
├─ request-promise-core@1.1.1
├─ request-promise-native@1.0.5
├─ request@2.88.0
├─ resolve-cwd@2.0.0
├─ resolve-url@0.2.1
├─ resolve@1.10.0
├─ restore-cursor@2.0.0
├─ ret@0.1.15
├─ rimraf@2.6.3
├─ rsvp@3.6.2
├─ run-async@2.3.0
├─ rx-lite-aggregates@4.0.8
├─ rx-lite@4.0.8
├─ safer-buffer@2.1.2
├─ sax@1.2.4
├─ semver@5.6.0
├─ send@0.16.2
├─ serialize-error@2.1.0
├─ set-blocking@2.0.0
├─ set-value@2.0.0
├─ setprototypeof@1.1.0
├─ shebang-regex@1.0.0
├─ shell-quote@1.6.1
├─ shellwords@0.1.1
├─ signal-exit@3.0.2
├─ simple-plist@1.0.0
├─ sisteransi@1.0.0
├─ slide@1.1.6
├─ snapdragon-node@2.1.1
├─ snapdragon-util@3.0.1
├─ source-map-resolve@0.5.2
├─ source-map-support@0.5.10
├─ source-map-url@0.4.0
├─ spdx-correct@3.1.0
├─ spdx-exceptions@2.2.0
├─ split-string@3.1.0
├─ sprintf-js@1.0.3
├─ sshpk@1.16.1
├─ stacktrace-parser@0.1.4
├─ static-extend@0.1.2
├─ statuses@1.3.1
├─ stealthy-require@1.1.1
├─ stream-buffers@2.2.0
├─ string_decoder@1.1.1
├─ string-width@2.1.1
├─ strip-ansi@3.0.1
├─ strip-json-comments@2.0.1
├─ supports-color@6.1.0
├─ symbol-tree@3.2.2
├─ tar@4.4.8
├─ temp@0.8.3
├─ test-exclude@5.1.0
├─ through@2.3.8
├─ through2@2.0.5
├─ time-stamp@1.1.0
├─ tmp@0.0.33
├─ tmpl@1.0.4
├─ to-fast-properties@2.0.0
├─ to-regex-range@2.1.1
├─ tough-cookie@2.5.0
├─ tunnel-agent@0.6.0
├─ tweetnacl@0.14.5
├─ typedarray@0.0.6
├─ uglify-es@3.3.9
├─ uglify-js@3.4.9
├─ ultron@1.0.2
├─ unicode-canonical-property-names-ecmascript@1.0.4
├─ unicode-match-property-ecmascript@1.0.4
├─ unicode-match-property-value-ecmascript@1.0.2
├─ unicode-property-aliases-ecmascript@1.0.4
├─ union-value@1.0.0
├─ unpipe@1.0.0
├─ unset-value@1.0.0
├─ uri-js@4.2.2
├─ urix@0.1.0
├─ use@3.1.1
├─ util-deprecate@1.0.2
├─ util.promisify@1.0.0
├─ utils-merge@1.0.1
├─ validate-npm-package-license@3.0.4
├─ vary@1.1.2
├─ verror@1.10.0
├─ w3c-hr-time@1.0.1
├─ walker@1.0.7
├─ watch@0.18.0
├─ whatwg-encoding@1.0.5
├─ whatwg-fetch@3.0.0
├─ whatwg-mimetype@2.3.0
├─ whatwg-url@6.5.0
├─ wide-align@1.1.3
├─ wordwrap@1.0.0
├─ write-file-atomic@1.3.4
├─ xcode@2.0.0
├─ xml-name-validator@3.0.0
├─ xml@1.0.1
├─ xmlbuilder@9.0.7
├─ xmldom@0.1.27
├─ xpipe@1.0.5
├─ xtend@4.0.1
├─ y18n@4.0.0
├─ yallist@3.0.3
└─ yargs-parser@11.1.1
✨  Done in 26.90s.
21:47:12 [rn-cli] INFO Setting up new React Native app in /Users/kacper/projects/xxx
21:47:12 [rn-cli] INFO Fetching template react-native-template-mobx...
yarn add v1.13.0
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
warning " > react-native@0.69.0" has unmet peer dependency "react@16.6.3".
warning "react-native > @react-native-community/cli@10.0.0" has incorrect peer dependency "react-native@^0.57.0".
warning "react-native > metro-react-native-babel-transformer@0.51.0" has unmet peer dependency "@babel/core@*".
warning "react-native > @react-native-community/cli > metro-react-native-babel-transformer@0.51.1" has unmet peer dependency "@babel/core@*".
[4/4] 🔨  Building fresh packages...
success Saved lockfile.
success Saved 1 new dependency.
info Direct dependencies
└─ react-native-template-mobx@0.0.6
info All dependencies
└─ react-native-template-mobx@0.0.6
✨  Done in 2.95s.
21:47:15 [rn-cli] INFO Adding dependencies for the project...
yarn add v1.13.0
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
warning " > react-native@0.69.0" has unmet peer dependency "react@16.6.3".
warning "react-native > @react-native-community/cli@10.0.0" has incorrect peer dependency "react-native@^0.57.0".
warning "react-native > metro-react-native-babel-transformer@0.51.0" has unmet peer dependency "@babel/core@*".
warning "react-native > @react-native-community/cli > metro-react-native-babel-transformer@0.51.1" has unmet peer dependency "@babel/core@*".
warning " > mobx-react@4.4.3" has unmet peer dependency "react@^0.13.0 || ^0.14.0 || ^15.0.0 || ^16.0.0".
warning " > react-navigation@1.6.1" has unmet peer dependency "react@*".
warning "react-navigation > react-native-safe-area-view@0.11.0" has unmet peer dependency "react@*".
warning "react-navigation > react-native-drawer-layout-polyfill > react-native-drawer-layout@1.3.2" has unmet peer dependency "react@*".
warning "react-navigation > react-native-tab-view@0.0.74" has unmet peer dependency "react@*".
[4/4] 🔨  Building fresh packages...
success Saved lockfile.
success Saved 18 new dependencies.
info Direct dependencies
├─ apisauce@0.12.0
├─ mobx-react@4.4.3
├─ mobx@3.6.2
├─ react-native-button@1.8.2
├─ react-native-smart-keyboard@1.0.0
├─ react-native-vector-icons@4.0.1
└─ react-navigation@1.6.1
info All dependencies
├─ apisauce@0.12.0
├─ axios@0.16.2
├─ clamp@1.0.1
├─ follow-redirects@1.6.1
├─ mobx-react@4.4.3
├─ mobx@3.6.2
├─ path-to-regexp@1.7.0
├─ ramda@0.23.0
├─ react-lifecycles-compat@3.0.4
├─ react-native-button@1.8.2
├─ react-native-dismiss-keyboard@1.0.0
├─ react-native-drawer-layout-polyfill@1.3.2
├─ react-native-drawer-layout@1.3.2
├─ react-native-safe-area-view@0.11.0
├─ react-native-smart-keyboard@1.0.0
├─ react-native-tab-view@0.0.74
├─ react-native-vector-icons@4.0.1
└─ react-navigation@1.6.1
✨  Done in 9.40s.
21:47:25 [rn-cli] INFO Linking native dependencies into the project's build files...
21:47:26 [rn-cli] WARN Running `react-native link` without package name is deprecated and will be removed in next release. If you use this command to link your project assets, please let us know about your use case here: https://goo.gl/RKTeoc
21:47:26 [rn-cli] INFO Linking react-native-smart-keyboard ios dependency
21:47:26 [rn-cli] INFO Platform 'ios' module react-native-smart-keyboard has been successfully linked
21:47:26 [rn-cli] INFO Linking react-native-vector-icons ios dependency
21:47:26 [rn-cli] INFO Platform 'ios' module react-native-vector-icons has been successfully linked
21:47:26 [rn-cli] INFO Linking react-native-vector-icons android dependency
21:47:26 [rn-cli] INFO Platform 'android' module react-native-vector-icons has been successfully linked
21:47:26 [rn-cli] INFO Adding develop dependencies for the project...
21:47:26 [rn-cli] INFO No additional develop dependencies.
yarn remove v1.13.0
[1/2] 🗑  Removing module react-native-template-mobx...
[2/2] 🔨  Regenerating lockfile and installing missing dependencies...
warning " > mobx-react@4.4.3" has unmet peer dependency "react@^0.13.0 || ^0.14.0 || ^15.0.0 || ^16.0.0".
warning " > react-native@0.69.0" has unmet peer dependency "react@16.6.3".
warning "react-native > @react-native-community/cli@10.0.0" has incorrect peer dependency "react-native@^0.57.0".
warning "react-native > metro-react-native-babel-transformer@0.51.0" has unmet peer dependency "@babel/core@*".
warning "react-native > @react-native-community/cli > metro-react-native-babel-transformer@0.51.1" has unmet peer dependency "@babel/core@*".
warning " > react-navigation@1.6.1" has unmet peer dependency "react@*".
warning "react-navigation > react-native-safe-area-view@0.11.0" has unmet peer dependency "react@*".
warning "react-navigation > react-native-tab-view@0.0.74" has unmet peer dependency "react@*".
warning "react-navigation > react-native-drawer-layout-polyfill > react-native-drawer-layout@1.3.2" has unmet peer dependency "react@*".
success Uninstalled packages.
✨  Done in 3.06s.
21:47:30 [rn-cli] INFO Adding required dependencies
yarn add v1.13.0
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
warning "react-native > @react-native-community/cli@10.0.0" has incorrect peer dependency "react-native@^0.57.0".
warning "react-native > metro-react-native-babel-transformer@0.51.0" has unmet peer dependency "@babel/core@*".
warning "react-native > @react-native-community/cli > metro-react-native-babel-transformer@0.51.1" has unmet peer dependency "@babel/core@*".
[4/4] 🔨  Building fresh packages...
success Saved lockfile.
success Saved 2 new dependencies.
info Direct dependencies
└─ react@16.6.3
info All dependencies
├─ react@16.6.3
└─ scheduler@0.11.3
✨  Done in 3.13s.
21:47:33 [rn-cli] INFO Adding required dev dependencies
yarn add v1.13.0
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
warning Pattern ["@babel/core@^7.2.2"] is trying to unpack in the same destination "/Users/kacper/Library/Caches/Yarn/v4/npm-@babel-core-7.2.2-07adba6dde27bb5ad8d8672f15fde3e08184a687/node_modules/@babel/core" as pattern ["@babel/core@^7.0.0","@babel/core@^7.0.0","@babel/core@^7.0.0","@babel/core@^7.0.0","@babel/core@^7.0.0","@babel/core@^7.0.0","@babel/core@^7.0.0","@babel/core@^7.1.0","@babel/core@^7.1.0"]. This could result in non-deterministic behavior, skipping.
warning Pattern ["@babel/runtime@^7.3.1"] is trying to unpack in the same destination "/Users/kacper/Library/Caches/Yarn/v4/npm-@babel-runtime-7.3.1-574b03e8e8a9898eaf4a872a92ea20b7846f6f2a/node_modules/@babel/runtime" as pattern ["@babel/runtime@^7.0.0"]. This could result in non-deterministic behavior, skipping.
warning Pattern ["metro-react-native-babel-preset@^0.51.1"] is trying to unpack in the same destination "/Users/kacper/Library/Caches/Yarn/v4/npm-metro-react-native-babel-preset-0.51.1-44aeeedfea37f7c2ab8f6f273fa71b90fe65f089/node_modules/metro-react-native-babel-preset" as pattern ["metro-react-native-babel-preset@0.51.1","metro-react-native-babel-preset@0.51.1"]. This could result in non-deterministic behavior, skipping.
[3/4] 🔗  Linking dependencies...
warning "react-native > @react-native-community/cli@10.0.0" has incorrect peer dependency "react-native@^0.57.0".
[4/4] 🔨  Building fresh packages...
success Saved lockfile.
success Saved 7 new dependencies.
info Direct dependencies
├─ @babel/core@7.2.2
├─ @babel/runtime@7.3.1
├─ babel-jest@24.1.0
├─ jest@24.1.0
├─ metro-react-native-babel-preset@0.51.1
└─ react-test-renderer@16.6.3
info All dependencies
├─ @babel/core@7.2.2
├─ @babel/runtime@7.3.1
├─ babel-jest@24.1.0
├─ jest@24.1.0
├─ metro-react-native-babel-preset@0.51.1
├─ react-is@16.8.1
└─ react-test-renderer@16.6.3
✨  Done in 3.28s.

  Run instructions for iOS:
    • cd /Users/kacper/projects/xxx && react-native run-ios
    - or -
    • Open ios/xxx.xcodeproj in Xcode
    • Hit the Run button

  Run instructions for Android:
    • Have an Android emulator running (quickest way to get started), or a device connected.
    • cd /Users/kacper/projects/xxx && react-native run-android

```

</details>