### PR TITLE
Support for template post install script

### DIFF
--- a/packages/cli/src/generator/templates.js
+++ b/packages/cli/src/generator/templates.js
@@ -95,7 +95,7 @@ function createFromRemoteTemplate(
     });
     installTemplateDependencies(templatePath, yarnVersion);
     installTemplateDevDependencies(templatePath, yarnVersion);
-    executePostInstallScript(templatePath);
+    executeTemplatePostInstallScript(templatePath);
   } finally {
     // Clean up the temp files
     try {
@@ -184,7 +184,7 @@ function installTemplateDevDependencies(templatePath, yarnVersion) {
   }
 }
 
-function executePostInstallScript(templatePath) {
+function executeTemplatePostInstallScript(templatePath) {
   // rn-template-post-install.js is a special Node.js script that is being executed
   // to do some extra work needed for this template
   const postInstallScriptPath = path.resolve(

--- a/packages/cli/src/generator/templates.js
+++ b/packages/cli/src/generator/templates.js
@@ -91,6 +91,7 @@ function createFromRemoteTemplate(
         'package.json',
         'dependencies.json',
         'devDependencies.json',
+        'rn-template-post-install.js',
       ],
     });
     installTemplateDependencies(templatePath, yarnVersion);

--- a/packages/cli/src/generator/templates.js
+++ b/packages/cli/src/generator/templates.js
@@ -95,6 +95,7 @@ function createFromRemoteTemplate(
     });
     installTemplateDependencies(templatePath, yarnVersion);
     installTemplateDevDependencies(templatePath, yarnVersion);
+    executePostInstallScript(templatePath);
   } finally {
     // Clean up the temp files
     try {
@@ -181,6 +182,24 @@ function installTemplateDevDependencies(templatePath, yarnVersion) {
       });
     }
   }
+}
+
+function executePostInstallScript(templatePath) {
+  // rn-template-post-install.js is a special Node.js script that is being executed
+  // to do some extra work needed for this template
+  const postInstallScriptPath = path.resolve(
+    templatePath,
+    'rn-template-post-install.js'
+  );
+  logger.info('Executing template post install script for the project...');
+  if (!fs.existsSync(postInstallScriptPath)) {
+    logger.info('No additional post install script.');
+    return;
+  }
+
+  execSync(`node ${postInstallScriptPath}`, {
+    stdio: 'inherit',
+  });
 }
 
 export { createProjectFromTemplate };


### PR DESCRIPTION
Summary:
---------

Thank you all for the work you've put into this CLI, I really appreciate it! 👍

With this PR I want to add support for template post install scripts. Those scripts come in handy when there's some extra work needed to set up the new project.

For example in the [TypeScript template](https://github.com/emin93/react-native-template-typescript) some extensions to the Jest configuration in the `package.json` have to be made. Instead of a manual process, a post install script could take care of it.


Test Plan:
----------

Went with the guide in the `CONTRIBUTION.md` document, installed Verdaccio, released a new version of React Native to it and used it to create a new project with a template that doesn't have a post install script and one that has it, to check if both scenarios will work.
