### PR TITLE
feat: show help when no arguments are provided

### DIFF
--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -70,16 +70,15 @@ function printHelpInformation() {
 }
 
 function printUnknownCommand(cmdName) {
-  logger.error(
-    [
-      cmdName
-        ? `Unrecognized command "${cmdName}".`
-        : "You didn't pass any command.",
-      `Run ${chalk.white(
-        '"react-native --help"'
-      )} to see list of all available commands.`,
-    ].join(' ')
-  );
+  cmdName
+    ? logger.error(
+        [
+          `Run ${chalk.white(
+            '"react-native --help"'
+          )} to see list of all available commands.`,
+        ].join(' ')
+      )
+    : commander.outputHelp();
 }
 
 const addCommand = (command: CommandT, ctx: ContextT) => {

--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -72,11 +72,10 @@ function printHelpInformation() {
 function printUnknownCommand(cmdName) {
   cmdName
     ? logger.error(
-        [
-          `Run ${chalk.white(
-            '"react-native --help"'
-          )} to see list of all available commands.`,
-        ].join(' ')
+        `Unrecognized command "${cmdName}".
+        Run ${chalk.white(
+          '"react-native --help"'
+        )} to see list of all available commands.`
       )
     : commander.outputHelp();
 }

--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -70,14 +70,16 @@ function printHelpInformation() {
 }
 
 function printUnknownCommand(cmdName) {
-  cmdName
-    ? logger.error(
-        `Unrecognized command "${cmdName}".
-        Run ${chalk.white(
-          '"react-native --help"'
-        )} to see list of all available commands.`
-      )
-    : commander.outputHelp();
+  if (cmdName) {
+    logger.error(`Unrecognized command "${chalk.bold(cmdName)}".`);
+    logger.info(
+      `Run ${chalk.bold(
+        '"react-native --help"'
+      )} to see a list of all available commands.`
+    );
+  } else {
+    commander.outputHelp();
+  }
 }
 
 const addCommand = (command: CommandT, ctx: ContextT) => {

--- a/packages/global-cli/index.js
+++ b/packages/global-cli/index.js
@@ -114,7 +114,7 @@ const commands = options._;
 if (cli) {
   cli.run();
 } else {
-  if (options._.length === 0 && (options.h || options.help)) {
+  if (options._.length === 0 && (options.h || options.help) || commands.length === 0) {
     console.log(
       [
         '',
@@ -134,13 +134,6 @@ if (cli) {
       ].join('\n')
     );
     process.exit(0);
-  }
-
-  if (commands.length === 0) {
-    console.error(
-      'You did not pass any commands, run `react-native --help` to see a list of all available commands.'
-    );
-    process.exit(1);
   }
 
   switch (commands[0]) {


### PR DESCRIPTION
Summary:
---------

This PR adds the default behaviour of calling the CLI without any args to be the `--help` command.

Fixes #158.

Test Plan:
----------

Run the following:

```bash
node path/to/the/react-native-cli/packages/cli/build/index.js
node path/to/the/react-native-cli/packages/global-cli/index.js
```
