### PR TITLE
fix: improve cli interface

### DIFF
--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -118,6 +118,11 @@ const addCommand = (command: CommandT, ctx: ContextT) => {
       typeof opt.default === 'function' ? opt.default(ctx) : opt.default
     )
   );
+
+  // Redefined here to appear in the `--help` section
+  cmd
+    .option('--projectRoot [string]', 'Path to the root of the project')
+    .option('--reactNativePath [string]', 'Path to React Native');
 };
 
 async function run() {

--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -185,9 +185,7 @@ async function setupAndRun() {
 
   if (!command) {
     commander.help();
-  }
-
-  if (typeof command === 'string') {
+  } else if (typeof command === 'string') {
     printUnknownCommand(commander.args);
   }
 }

--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -21,7 +21,10 @@ import assertRequiredOptions from './util/assertRequiredOptions';
 import logger from './util/logger';
 import pkg from '../package.json';
 
-commander.version(pkg.version);
+commander
+  .version(pkg.version)
+  .option('--projectRoot [string]', 'Path to the root of the project')
+  .option('--reactNativePath [string]', 'Path to React Native');
 
 const defaultOptParser = val => val;
 
@@ -115,10 +118,6 @@ const addCommand = (command: CommandT, ctx: ContextT) => {
       typeof opt.default === 'function' ? opt.default(ctx) : opt.default
     )
   );
-
-  cmd
-    .option('--projectRoot [string]', 'Path to the root of the project')
-    .option('--reactNativePath [string]', 'Path to React Native');
 };
 
 async function run() {
@@ -177,17 +176,14 @@ async function setupAndRun() {
 
   commander.parse(process.argv);
 
-  const isValidCommand = commands.find(
-    cmd => cmd.name.split(' ')[0] === process.argv[2]
-  );
+  const command = commander.args[0];
 
-  if (!isValidCommand) {
-    printUnknownCommand(process.argv[2]);
-    return;
+  if (!command) {
+    commander.help();
   }
 
-  if (!commander.args.length) {
-    commander.help();
+  if (typeof command === 'string') {
+    printUnknownCommand(commander.args);
   }
 }
 

--- a/packages/cli/src/generator/printRunInstructions.js
+++ b/packages/cli/src/generator/printRunInstructions.js
@@ -13,7 +13,7 @@ import chalk from 'chalk';
 import logger from '../util/logger';
 
 function printRunInstructions(projectDir: string, projectName: string) {
-  const relativeProjectDir = path.relative(process.cwd(), projectDir);
+  const absoluteProjectDir = path.resolve(projectDir);
   const xcodeProjectPath = `${path.resolve(
     projectDir,
     'ios',
@@ -26,14 +26,14 @@ function printRunInstructions(projectDir: string, projectName: string) {
 
   logger.log(`
   ${chalk.cyan(`Run instructions for ${chalk.bold('iOS')}`)}:
-    • cd ${relativeProjectDir} && react-native run-ios
+    • cd ${absoluteProjectDir} && react-native run-ios
     - or -
     • Open ${relativeXcodeProjectPath} in Xcode
     • Hit the Run button
 
   ${chalk.green(`Run instructions for ${chalk.bold('Android')}`)}:
     • Have an Android emulator running (quickest way to get started), or a device connected.
-    • cd ${relativeProjectDir} && react-native run-android
+    • cd ${absoluteProjectDir} && react-native run-android
 `);
 }
 


### PR DESCRIPTION
Summary:
---------

This fixes few of the issues that I've encountered working in a React Native repository.

When you pass a wrong command or provide no command at all (say, you want to print `--help`) and your CLI works by setting `--projectRoot` or `--reactNativePath` (in React Native repository, this is a must), you end up with a "Unrecognised option" error.

This PR changes that, so that it works and is accepted.

It also fixes a missing path to a inited application that is a regression introduced in https://github.com/react-native-community/react-native-cli/commit/72c3dd4282996891442c3ec779e99d989a74c440#diff-d9b7abe65a1a1a0e0b19ec93292008eaR16. We wrongly assumed `process.cwd()` remains the directory the command has been run from. Turns out, it's modified by the init script.