### PR TITLE
Return full file path for `InitializeCore` incl. extension

### DIFF
--- a/packages/cli/src/util/loadMetroConfig.js
+++ b/packages/cli/src/util/loadMetroConfig.js
@@ -48,7 +48,9 @@ const getDefaultConfig = (ctx: ContextT) => {
     },
     serializer: {
       getModulesRunBeforeMainModule: () => [
-        require.resolve(path.join(ctx.reactNativePath, 'Libraries/Core/InitializeCore')),
+        require.resolve(
+          path.join(ctx.reactNativePath, 'Libraries/Core/InitializeCore')
+        ),
       ],
       getPolyfills: () =>
         require(path.join(ctx.reactNativePath, 'rn-get-polyfills'))(),

--- a/packages/cli/src/util/loadMetroConfig.js
+++ b/packages/cli/src/util/loadMetroConfig.js
@@ -48,7 +48,7 @@ const getDefaultConfig = (ctx: ContextT) => {
     },
     serializer: {
       getModulesRunBeforeMainModule: () => [
-        path.join(ctx.reactNativePath, 'Libraries/Core/InitializeCore'),
+        require.resolve(path.join(ctx.reactNativePath, 'Libraries/Core/InitializeCore')),
       ],
       getPolyfills: () =>
         require(path.join(ctx.reactNativePath, 'rn-get-polyfills'))(),


### PR DESCRIPTION
Summary:
---------

This fixes the 2nd issue as described here: https://github.com/react-native-community/react-native-releases/issues/79#issuecomment-463394781


Test Plan:
----------

As indicated on https://github.com/react-native-community/react-native-releases/issues/79#issuecomment-463394781 - without this change various errors occur due to missing globals, with this change applied these errors no longer occur on my local project tested with Detox:

![image](https://user-images.githubusercontent.com/5347038/52750251-aabb6400-2fe3-11e9-8d0e-418201400f10.png)


