### PR TITLE
fix: update react-native-cli README

### DIFF
--- a/packages/global-cli/README.md
+++ b/packages/global-cli/README.md
@@ -24,7 +24,7 @@ It will install `react-native`, `react`, `jest` and a bunch of other necessary p
 
 After it's finished, your AwesomeProject should be ready to use. From this point, you should use your local `react-native` binary to run the proper [React Native CLI](../cli):
 
-```
+```sh
 yarn react-native link native-dep
 ```
 
@@ -36,7 +36,7 @@ Use a custom template.
 
 Example: this will install init your AwesomeProject using template called `react-native-template-samplename` from npm:
 
-```
+```sh
 react-native init AwesomeProject --template samplename
 ```
 
@@ -48,8 +48,14 @@ Use a custom version. By default `react-native init` will use the latest stable.
 
 Example: this will install init your AwesomeProject using version `0.57.0`:
 
+```sh
+react-native init AwesomeProject --version 0.57.0
 ```
-react-native init AwesomeProject --template 0.57.0
+
+You can also install a specific tag, like `next`, using:
+
+```sh
+react-native init AwesomeProject --version react-native@next
 ```
 
 ## Future work

--- a/packages/global-cli/README.md
+++ b/packages/global-cli/README.md
@@ -56,4 +56,4 @@ react-native init AwesomeProject --template 0.57.0
 
 We understand this is counter-intuitive to have two packages for interacting with React Native and it makes the first experience with the framework a bit confusing.
 
-That's why, as a part of [Lean Core](https://github.com/facebook/react-native/issues/23313) initiative, there's an ongoing effort to remove this module so we can use just `react-native` as the only package necessary to install and run React Native commands.
+That's why, as a part of [Lean Core](https://github.com/facebook/react-native/issues/23313) initiative, there's an [ongoing effort](https://github.com/react-native-community/react-native-cli/issues/76) to remove this module so we can use just `react-native` as the only package necessary to install and run React Native commands.

--- a/packages/global-cli/README.md
+++ b/packages/global-cli/README.md
@@ -2,22 +2,54 @@
 
 `react-native-cli` is a command line tool for initializing React Native projects.
 
-## Usage
+## Installation
 
-We recommend using `react-native-cli` with `npx` so you don't need to pollute your global packages scope.
+Install it as a global module:
+
+```sh
+yarn global add react-native-cli
+```
+
+It will create a global `react-native` binary (even though the package name is `react-native-cli`).
+
+## Usage
 
 To create a new React Native Project called "AwesomeProject" you can run:
 
 ```sh
-npx react-native-cli init AwesomeProject
+react-native init AwesomeProject
 ```
 
-It will install `react-native`, `react`, `jest` and a bunch of other necessary packages from the default template.
+It will install `react-native`, `react`, `jest` and a bunch of other necessary packages from the [default template](https://github.com/facebook/react-native/tree/master/template).
 
 After it's finished, your AwesomeProject should be ready to use. From this point, you should use your local `react-native` binary to run the proper [React Native CLI](../cli):
 
 ```
 yarn react-native link native-dep
+```
+
+## Options
+
+### `--template`
+
+Use a custom template.
+
+Example: this will install init your AwesomeProject using template called `react-native-template-samplename` from npm:
+
+```
+react-native init AwesomeProject --template samplename
+```
+
+You can also pass remote git address and local filepath as a `--template` parameter.
+
+### `--version`
+
+Use a custom version. By default `react-native init` will use the latest stable.
+
+Example: this will install init your AwesomeProject using version `0.57.0`:
+
+```
+react-native init AwesomeProject --template 0.57.0
 ```
 
 ## Future work

--- a/packages/global-cli/README.md
+++ b/packages/global-cli/README.md
@@ -1,126 +1,27 @@
-## Running CLI with local modifications
+## React Native Global CLI
 
-React Native is distributed as two npm packages, `react-native-cli` and `react-native`. The first one is a lightweight package that should be installed globally (`npm install -g react-native-cli`), while the second one contains the actual React Native framework code and is installed locally into your project when you run `react-native init`.
+`react-native-cli` is a command line tool for initializing React Native projects.
 
-Because `react-native init` calls `npm install react-native`, simply linking your local github clone into npm is not enough to test local changes.
+## Usage
 
-### Introducing Sinopia
+We recommend using `react-native-cli` with `npx` so you don't need to pollute your global packages scope.
 
-[Sinopia] is an npm registry that runs on your local machine and allows you to publish packages to it. Everything else is proxied from `npmjs.com`. We'll set up sinopia for React Native CLI development. First, install it with:
+To create a new React Native Project called "AwesomeProject" you can run:
 
-    $ npm install -g sinopia
+```sh
+npx react-native-cli init AwesomeProject
+```
 
-Now you can run sinopia by simply doing:
+It will install `react-native`, `react`, `jest` and a bunch of other necessary packages from the default template.
 
-    $ sinopia
+After it's finished, your AwesomeProject should be ready to use. From this point, you should use your local `react-native` binary to run the proper [React Native CLI](../cli):
 
-Running it for the first time creates a default config file. Open `~/.config/sinopia/config.yaml` and configure it like this (note the `max_body_size`):
+```
+yarn react-native link native-dep
+```
 
-    storage: ./storage
+## Future work
 
-    auth:
-      htpasswd:
-        file: ./htpasswd
+We understand this is counter-intuitive to have two packages for interacting with React Native and it makes the first experience with the framework a bit confusing.
 
-    uplinks:
-      npmjs:
-        url: https://registry.npmjs.org/
-
-    packages:
-      'react-native':
-        allow_access: $all
-        allow_publish: $all
-
-      'react-native-cli':
-        allow_access: $all
-        allow_publish: $all
-
-      '**':
-        allow_access: $all
-        proxy: npmjs
-
-      '*':
-        allow_access: $all
-        proxy: npmjs
-
-    logs:
-      - {type: stdout, format: pretty, level: http}
-
-    max_body_size: '50mb'
-
-Remember to restart sinopia afterwards.
-
-### Publishing to sinopia
-
-Now we need to publish the two React Native packages to our local registry. To do this, we configure npm to use the new registry, unpublish any existing packages and then publish the new ones:
-
-    react-native$ npm set registry http://localhost:4873/
-    react-native$ npm adduser --registry http://localhost:4873/
-    # Check that it worked:
-    react-native$ npm config list
-    react-native$ npm unpublish --force
-    react-native$ npm publish
-    react-native$ cd react-native-cli/
-    react-native-cli$ npm unpublish --force
-    react-native-cli$ npm publish
-
-### Running the local CLI
-
-Now that the packages are installed in sinopia, you can install the new `react-native-cli` package globally and when you use `react-native init`, it will install the new `react-native` package as well:
-
-    $ npm uninstall -g react-native-cli
-    $ npm install -g react-native-cli
-    $ react-native init AwesomeApp
-
-## Testing changes
-
-Most of the CLI code is covered by jest tests, which you can run with:
-
-    $ npm test
-
-Project generation is also covered by e2e tests, which you can run with:
-
-    $ ./scripts/e2e-test.sh
-
-These tests actually create a very similar setup to what is described above (using sinopia) and they also run iOS-specific tests, so you will need to run this on OSX and have [xctool] installed.
-
-Both of these types of tests also run on Travis both continuously and on pull requests.
-
-[sinopia]: https://www.npmjs.com/package/sinopia
-[xctool]: https://github.com/facebook/xctool
-
-## Clean up
-
-To unset the npm registry, do:
-
-    $ npm set registry https://registry.npmjs.org/
-    # Check that it worked:
-    $ npm config list
-
-## Troubleshooting
-
-##### Sinopia crashes with "Module version mismatch"
-
-This usually happens when you install a package using one version of Node and then change to a different version. This can happen when you update Node, or switch to a different version with nvm. Do:
-
-    $ npm uninstall -g sinopia
-    $ npm install -g sinopia
-
-After upgrading to Node 4 you might also need to reinstall npm. What worked for me was:
-
-    $ npm uninstall -g npm
-    $ nvm install npm
-
- See the [nvm guide](https://github.com/creationix/nvm#usage) for more info.
-
-### Alternative workflow
-
-If you don't want to install Sinopia you could still test changes done on the cli by creating a sample project and installing your checkout of `react-native` on that project instead of downloading it from npm. The simplest way to do this is by:
-
-    $ npm init AwesomeProject
-    $ cd AwesomeProject
-    $ npm install $REACT_NATIVE_GITHUB
-
-Note that `REACT_NATIVE_GITHUB` should point to the directory where you have a checkout.
-
-Also, if the changes you're making get triggered when running `react-native init AwesomeProject` you will want to tweak the global installed `react-native-cli` library to install the local checkout instead of downloading the module from npm. To do so just change this [line](https://github.com/facebook/react-native/blob/master/react-native-cli/index.js#L191) and refer the local checkout instead.
+That's why, as a part of [Lean Core](https://github.com/facebook/react-native/issues/23313) initiative, there's an ongoing effort to remove this module so we can use just `react-native` as the only package necessary to install and run React Native commands.


### PR DESCRIPTION
Summary:
---------

Current README of `react-native-cli` is outdated and totally not user friendly. We already have a contributing guide on how to run it locally, so there's no point in keeping this one. I took this opportunity to write a proper README.

cc @kelset 