### PR TITLE
Export `getDefaultConfig` for custom configurations

### DIFF
--- a/packages/cli/src/util/loadMetroConfig.js
+++ b/packages/cli/src/util/loadMetroConfig.js
@@ -32,7 +32,7 @@ const getBlacklistRE = () => createBlacklist([/.*\/__fixtures__\/.*/]);
  * @todo(grabbou): As a separate PR, haste.platforms should be added before "native".
  * Otherwise, a.native.js will not load on Windows or other platforms
  */
-const getDefaultConfig = (ctx: ContextT) => {
+export const getDefaultConfig = (ctx: ContextT) => {
   const plugins = findPlugins(ctx.root);
 
   return {


### PR DESCRIPTION
Summary:
---------

This PR addresses the first issue described in [this comment](https://github.com/react-native-community/react-native-releases/issues/79?#issuecomment-463394781).

**Example usage before CLI was moved**: 
See https://github.com/ueno-llc/react-native-starter/blob/master/metro.config.js

**Example usage after move + this PR:**
```js
// metro.config.js
const { resolve } = require('path');
const { mergeConfig } = require('metro-config');
const { getDefaultConfig } = require('@react-native-community/cli/build/util/loadMetroConfig');

const root = __dirname;
const reactNativePath = resolve(root, './node_modules/react-native');

const config = {
  resolver: {
    sourceExts: ['js', 'json', 'ts', 'tsx', 'css', 'scss'],
  },
  transformer: {
    babelTransformerPath: require.resolve('./scripts/transformer.js'),
  },
};

module.exports = mergeConfig(getDefaultConfig({ root, reactNativePath }), config);
```

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
