### PR TITLE
exclude debug folder from findManifest command

### DIFF
--- a/packages/cli/src/core/android/findManifest.js
+++ b/packages/cli/src/core/android/findManifest.js
@@ -24,7 +24,7 @@ export default function findManifest(folder) {
       '**/build/**',
       '**/debug/**',
       'Examples/**',
-      'examples/**'
+      'examples/**',
     ],
   })[0];
 

--- a/packages/cli/src/core/android/findManifest.js
+++ b/packages/cli/src/core/android/findManifest.js
@@ -19,7 +19,13 @@ import path from 'path';
 export default function findManifest(folder) {
   const manifestPath = glob.sync(path.join('**', 'AndroidManifest.xml'), {
     cwd: folder,
-    ignore: ['node_modules/**', '**/build/**', '**/debug/**', 'Examples/**', 'examples/**'],
+    ignore: [
+      'node_modules/**',
+      '**/build/**',
+      '**/debug/**',
+      'Examples/**',
+      'examples/**'
+    ],
   })[0];
 
   return manifestPath ? path.join(folder, manifestPath) : null;

--- a/packages/cli/src/core/android/findManifest.js
+++ b/packages/cli/src/core/android/findManifest.js
@@ -19,7 +19,7 @@ import path from 'path';
 export default function findManifest(folder) {
   const manifestPath = glob.sync(path.join('**', 'AndroidManifest.xml'), {
     cwd: folder,
-    ignore: ['node_modules/**', '**/build/**', 'Examples/**', 'examples/**'],
+    ignore: ['node_modules/**', '**/build/**', '**/debug/**', 'Examples/**', 'examples/**'],
   })[0];
 
   return manifestPath ? path.join(folder, manifestPath) : null;


### PR DESCRIPTION
Summary:
---------
Due to changes in Android, we have 2 AndroidManifest.xml files in RN template, one in the main and another in debug. Manifest in debug has no package name, so that developer has to edit only AndroidManifest.xml in main if they want to change package name.

But it's causing link failure like below, so it's best to not look into debug for AndroidManifest.xml files.

```js
info Run "react-native --help" to see a list of all available commands.
error No package found. Are you sure this is a React Native project?
error Package name not found in
<redacted>/android/app/src/debug/AndroidManifest.xml
```

Test Plan:
----------

Try to link any module with 0.59RC template, it'll fail. but after this patch it'll work. 