### PR TITLE
fix: printing error and unknown command messages when unnecessary

### DIFF
--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -26,6 +26,11 @@ commander
   .option('--projectRoot [string]', 'Path to the root of the project')
   .option('--reactNativePath [string]', 'Path to React Native');
 
+commander.on('command:*', () => {
+  printUnknownCommand(commander.args.join(' '));
+  process.exit(1);
+});
+
 const defaultOptParser = val => val;
 
 const handleError = err => {
@@ -181,12 +186,8 @@ async function setupAndRun() {
 
   commander.parse(process.argv);
 
-  const command = commander.args[0];
-
-  if (!command) {
-    commander.help();
-  } else if (typeof command === 'string') {
-    printUnknownCommand(commander.args);
+  if (!options._.length) {
+    commander.outputHelp();
   }
 }
 


### PR DESCRIPTION
Summary:
---------

The logic for printing an unknown command was always a hack and the one for printing a help when no command provided never worked.

I did a research and found out there's a recommended (Commander way) of doing this.

It also fixes a regression I've noticed in https://github.com/react-native-community/react-native-releases/issues/79#issuecomment-463933483

![](https://user-images.githubusercontent.com/5376380/52840468-f711bb80-312b-11e9-9bb3-65b9676e3132.png)

Test Plan:
----------

Run w/o command, run with wrong command.