### PR TITLE
feat: refactor install to use link directly instead of spawning it

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ node ./node_modules/.bin/react-native start
 
 You can also add npm scripts to call it with whichever package manager you use:
 
-```json5
+```json
 {
   "scripts": {
     "start": "react-native start"

--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
  * @flow
  */
 

--- a/packages/cli/src/core/getCommands.js
+++ b/packages/cli/src/core/getCommands.js
@@ -74,10 +74,8 @@ const loadProjectCommands = (root: string): Array<ProjectCommandT> => {
             .join(path.sep)
         : pathToCommands.split(path.sep)[0];
 
-    // $FlowFixMe: Non-literal require
     const pkg = require(path.join(root, 'node_modules', name, 'package.json'));
 
-    // $FlowFixMe: Non-literal require
     const requiredCommands:
       | ProjectCommandT
       | Array<ProjectCommandT> = require(path.join(

--- a/packages/cli/src/core/getPlatforms.js
+++ b/packages/cli/src/core/getPlatforms.js
@@ -45,3 +45,12 @@ export default function getPlatforms(root: string): PlatformsT {
     ...projectPlatforms,
   };
 }
+
+const names = {
+  ios: 'iOS',
+  android: 'Android',
+};
+
+export function getPlatformName(name: string) {
+  return names[name] || name;
+}

--- a/packages/cli/src/core/types.flow.js
+++ b/packages/cli/src/core/types.flow.js
@@ -107,6 +107,15 @@ export type DependencyConfigT = {
   ios: ?DependencyConfigIOST,
 };
 
+export type DependenciesConfig = {
+  config: DependencyConfigT,
+  name: string,
+  path: string,
+  assets: string[],
+  commands: { [name: string]: string },
+  params: InquirerPromptT[],
+};
+
 /**
  * Available platforms. Additional plugins should assert the type on their own.
  */

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
+ * @flow
  */
 
 // gracefulify() has to be called before anything else runs

--- a/packages/cli/src/install/install.js
+++ b/packages/cli/src/install/install.js
@@ -4,30 +4,25 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
+ * @flow
  */
 
-import { spawnSync } from 'child_process';
+import type { ContextT } from '../core/types.flow';
 import logger from '../util/logger';
 import PackageManager from '../util/PackageManager';
+import link from '../link/link';
 
-const spawnOpts = {
-  stdio: 'inherit',
-  stdin: 'inherit',
-};
-
-async function install(args, ctx) {
+async function install(args: Array<string>, ctx: ContextT) {
   const name = args[0];
 
+  logger.info(`Installing "${name}"...`);
   new PackageManager({ projectDir: ctx.root }).install([name]);
 
-  const res = spawnSync('react-native', ['link', name], spawnOpts);
+  logger.info(`Linking "${name}"...`);
+  // eslint-disable-next-line import/no-named-as-default-member
+  await link.func([name], ctx, { platforms: [] });
 
-  if (res.status) {
-    process.exit(res.status);
-  }
-
-  logger.info(`Module ${name} has been successfully installed & linked`);
+  logger.success(`Successfully installed and linked "${name}"`);
 }
 
 export default {

--- a/packages/cli/src/install/install.js
+++ b/packages/cli/src/install/install.js
@@ -20,7 +20,7 @@ async function install(args: Array<string>, ctx: ContextT) {
 
   logger.info(`Linking "${name}"...`);
   // eslint-disable-next-line import/no-named-as-default-member
-  await link.func([name], ctx, { platforms: [] });
+  await link.func([name], ctx, { platforms: undefined });
 
   logger.success(`Successfully installed and linked "${name}"`);
 }

--- a/packages/cli/src/install/uninstall.js
+++ b/packages/cli/src/install/uninstall.js
@@ -4,30 +4,24 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
+ * @flow
  */
 
-import { spawnSync } from 'child_process';
+import type { ContextT } from '../core/types.flow';
 import logger from '../util/logger';
 import PackageManager from '../util/PackageManager';
+import link from '../link/unlink';
 
-const spawnOpts = {
-  stdio: 'inherit',
-  stdin: 'inherit',
-};
-
-async function uninstall(args, ctx) {
+async function uninstall(args: Array<string>, ctx: ContextT) {
   const name = args[0];
 
-  const res = spawnSync('react-native', ['unlink', name], spawnOpts);
+  logger.info(`Unlinking "${name}"...`);
+  await link.func([name], ctx);
 
-  if (res.status) {
-    process.exit(res.status);
-  }
-
+  logger.info(`Uninstalling "${name}"...`);
   new PackageManager({ projectDir: ctx.root }).uninstall([name]);
 
-  logger.info(`Module ${name} has been successfully uninstalled & unlinked`);
+  logger.success(`Successfully uninstalled and unlinked "${name}"`);
 }
 
 export default {

--- a/packages/cli/src/link/__tests__/link-test.js
+++ b/packages/cli/src/link/__tests__/link-test.js
@@ -224,11 +224,15 @@ describe('link', () => {
       commands: {},
     }));
 
-    jest.doMock('../../core/getPlatforms', () => () => ({
-      ios: { linkConfig: require('../ios').default },
-      android: { linkConfig: require('../android').default },
-      windows: { linkConfig: genericLinkConfig },
-    }));
+    jest.doMock('../../core/getPlatforms', () => {
+      const fn = () => ({
+        ios: { linkConfig: require('../ios').default },
+        android: { linkConfig: require('../android').default },
+        windows: { linkConfig: genericLinkConfig },
+      });
+      fn.getPlatformName = jest.fn();
+      return fn;
+    });
 
     jest.doMock('../getDependencyConfig', () => getDependencyConfig);
 
@@ -269,10 +273,14 @@ describe('link', () => {
       register: registerIOSNativeModule,
     });
 
-    jest.doMock('../../core/getPlatforms', () => () => ({
-      android: { linkConfig: genericAndroidLinkConfig },
-      ios: { linkConfig: genericIOSLinkConfig },
-    }));
+    jest.doMock('../../core/getPlatforms', () => {
+      const fn = () => ({
+        android: { linkConfig: genericAndroidLinkConfig },
+        ios: { linkConfig: genericIOSLinkConfig },
+      });
+      fn.getPlatformName = jest.fn();
+      return fn;
+    });
 
     jest.doMock(
       '../android/registerNativeModule.js',

--- a/packages/cli/src/link/getDependencyConfig.js
+++ b/packages/cli/src/link/getDependencyConfig.js
@@ -6,23 +6,13 @@ import path from 'path';
 import type {
   PlatformsT,
   ContextT,
-  InquirerPromptT,
-  DependencyConfigT,
+  DependenciesConfig,
 } from '../core/types.flow';
 
 import getPackageConfiguration from '../core/getPackageConfiguration';
 import getParams from '../core/getParams';
 import getHooks from '../core/getHooks';
 import getAssets from '../core/getAssets';
-
-type DependenciesConfig = {
-  config: DependencyConfigT,
-  name: string,
-  path: string,
-  assets: string[],
-  commands: { [name: string]: string },
-  params: InquirerPromptT[],
-};
 
 export default function getDependencyConfig(
   ctx: ContextT,

--- a/packages/cli/src/link/getProjectDependencies.js
+++ b/packages/cli/src/link/getProjectDependencies.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
+ * @flow
  */
 
 import path from 'path';
@@ -23,9 +23,9 @@ const EXCLUDED_PROJECTS = [
 /**
  * Returns an array of dependencies that should be linked/checked.
  */
-export default function getProjectDependencies(cwd) {
-  const pjson = require(path.join(cwd, './package.json'));
-  return Object.keys(pjson.dependencies || {}).filter(
+export default function getProjectDependencies(cwd: string) {
+  const pkgJson = require(path.join(cwd, './package.json'));
+  return (Object.keys(pkgJson.dependencies || {}).filter(
     name => EXCLUDED_PROJECTS.includes(name) === false
-  );
+  ): Array<string>);
 }

--- a/packages/cli/src/link/link.js
+++ b/packages/cli/src/link/link.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
  * @flow
  */
 
@@ -12,7 +11,7 @@ import { pick } from 'lodash';
 import type { ContextT } from '../core/types.flow';
 
 import promiseWaterfall from './promiseWaterfall';
-import log from '../util/logger';
+import logger from '../util/logger';
 import getDependencyConfig from './getDependencyConfig';
 import commandStub from './commandStub';
 import promisify from './promisify';
@@ -43,7 +42,9 @@ function link([rawPackageName]: Array<string>, ctx: ContextT, opts: FlagsType) {
     }
     project = getProjectConfig(ctx, platforms);
   } catch (err) {
-    log.error('No package found. Are you sure this is a React Native project?');
+    logger.error(
+      'No package found. Are you sure this is a React Native project?'
+    );
     return Promise.reject(err);
   }
   const hasProjectConfig = Object.keys(platforms).reduce(
@@ -77,7 +78,7 @@ function link([rawPackageName]: Array<string>, ctx: ContextT, opts: FlagsType) {
   ];
 
   return promiseWaterfall(tasks).catch(err => {
-    log.error(
+    logger.error(
       `Something went wrong while linking. Error: ${err.message} \n` +
         'Please file an issue here: https://github.com/facebook/react-native/issues'
     );

--- a/packages/cli/src/link/link.js
+++ b/packages/cli/src/link/link.js
@@ -23,7 +23,7 @@ import findReactNativeScripts from '../util/findReactNativeScripts';
 import getPlatforms from '../core/getPlatforms';
 
 type FlagsType = {
-  platforms: Array<string>,
+  platforms?: Array<string>,
 };
 
 /**

--- a/packages/cli/src/link/linkAll.js
+++ b/packages/cli/src/link/linkAll.js
@@ -3,7 +3,7 @@
 import { uniqBy, flatten } from 'lodash';
 import path from 'path';
 import type { ContextT, PlatformsT, ProjectConfigT } from '../core/types.flow';
-import log from '../util/logger';
+import logger from '../util/logger';
 import getAssets from '../core/getAssets';
 import getProjectDependencies from './getProjectDependencies';
 import getDependencyConfig from './getDependencyConfig';
@@ -20,7 +20,7 @@ function linkAll(
   platforms: PlatformsT,
   project: ProjectConfigT
 ) {
-  log.warn(
+  logger.warn(
     'Running `react-native link` without package name is deprecated and will be removed ' +
       'in next release. If you use this command to link your project assets, ' +
       'please let us know about your use case here: https://goo.gl/RKTeoc'
@@ -49,7 +49,7 @@ function linkAll(
   );
 
   return promiseWaterfall(tasks).catch(err => {
-    log.error(
+    logger.error(
       `Something went wrong while linking. Error: ${err.message} \n` +
         'Please file an issue here: https://github.com/facebook/react-native/issues'
     );

--- a/packages/cli/src/link/linkAssets.js
+++ b/packages/cli/src/link/linkAssets.js
@@ -1,14 +1,18 @@
 // @flow
 
 import { isEmpty } from 'lodash';
-import type { PlatformsT, ProjectConfigT } from '../core/types.flow';
+import type {
+  PlatformsT,
+  ProjectConfigT,
+  DependenciesConfig,
+} from '../core/types.flow';
 
-import log from '../util/logger';
+import logger from '../util/logger';
 
 const linkAssets = (
   platforms: PlatformsT,
   project: ProjectConfigT,
-  dependency: *
+  dependency: DependenciesConfig
 ) => {
   if (isEmpty(dependency.assets)) {
     return;
@@ -24,12 +28,12 @@ const linkAssets = (
       return;
     }
 
-    log.info(`Linking assets to ${platform} project`);
+    logger.info(`Linking assets to ${platform} project`);
     // $FlowFixMe: We check for existence of project[platform]
     linkConfig.copyAssets(dependency.assets, project[platform]);
   });
 
-  log.info('Assets have been successfully linked to your project');
+  logger.info('Assets have been successfully linked to your project');
 };
 
 export default linkAssets;

--- a/packages/cli/src/link/linkDependency.js
+++ b/packages/cli/src/link/linkDependency.js
@@ -1,15 +1,18 @@
 // @flow
 
-import chalk from 'chalk';
-import type { PlatformsT, ProjectConfigT } from '../core/types.flow';
-
-import log from '../util/logger';
+import type {
+  PlatformsT,
+  ProjectConfigT,
+  DependenciesConfig,
+} from '../core/types.flow';
+import logger from '../util/logger';
 import pollParams from './pollParams';
+import { getPlatformName } from '../core/getPlatforms';
 
 const linkDependency = async (
   platforms: PlatformsT,
   project: ProjectConfigT,
-  dependency: *
+  dependency: DependenciesConfig
 ) => {
   const params = await pollParams(dependency.params);
 
@@ -34,29 +37,30 @@ const linkDependency = async (
     );
 
     if (isInstalled) {
-      log.info(
-        chalk.grey(
-          `Platform '${platform}' module ${dependency.name} is already linked`
-        )
+      logger.info(
+        `${getPlatformName(platform)} module "${
+          dependency.name
+        }" is already linked`
       );
       return;
     }
 
-    log.info(`Linking ${dependency.name} ${platform} dependency`);
+    logger.info(
+      `Linking "${dependency.name}" ${getPlatformName(platform)} dependency`
+    );
 
     linkConfig.register(
       dependency.name,
-      // $FlowFixMe: We check if dependency.config[platform] exists on line 42
-      dependency.config[platform],
+      dependency.config[platform] || {},
       params,
       // $FlowFixMe: We check if project[platform] exists on line 42
       project[platform]
     );
 
-    log.info(
-      `Platform '${platform}' module ${
+    logger.success(
+      `${getPlatformName(platform)} module "${
         dependency.name
-      } has been successfully linked`
+      }" has been successfully linked`
     );
   });
 };

--- a/packages/cli/src/link/linkDependency.js
+++ b/packages/cli/src/link/linkDependency.js
@@ -57,7 +57,7 @@ const linkDependency = async (
       project[platform]
     );
 
-    logger.success(
+    logger.info(
       `${getPlatformName(platform)} module "${
         dependency.name
       }" has been successfully linked`

--- a/packages/cli/src/link/unlink.js
+++ b/packages/cli/src/link/unlink.js
@@ -65,7 +65,7 @@ const unlinkDependency = (
       otherDependencies
     );
 
-    logger.success(
+    logger.info(
       `${getPlatformName(platform)} module "${
         dependency.name
       }" has been successfully unlinked`

--- a/packages/cli/src/link/unlink.js
+++ b/packages/cli/src/link/unlink.js
@@ -9,16 +9,14 @@
 
 import { flatten, isEmpty, difference } from 'lodash';
 import type { ContextT } from '../core/types.flow';
-
-import log from '../util/logger';
+import logger from '../util/logger';
 import getProjectConfig from './getProjectConfig';
 import getDependencyConfig from './getDependencyConfig';
 import getProjectDependencies from './getProjectDependencies';
 import promiseWaterfall from './promiseWaterfall';
 import commandStub from './commandStub';
 import promisify from './promisify';
-
-import getPlatforms from '../core/getPlatforms';
+import getPlatforms, { getPlatformName } from '../core/getPlatforms';
 
 const unlinkDependency = (
   platforms,
@@ -48,11 +46,15 @@ const unlinkDependency = (
     );
 
     if (!isInstalled) {
-      log.info(`Platform '${platform}' module ${packageName} is not installed`);
+      logger.info(
+        `${getPlatformName(platform)} module "${packageName}" is not installed`
+      );
       return;
     }
 
-    log.info(`Unlinking ${packageName} ${platform} dependency`);
+    logger.info(
+      `Unlinking "${packageName}" ${getPlatformName(platform)} dependency`
+    );
 
     linkConfig.unregister(
       packageName,
@@ -63,10 +65,10 @@ const unlinkDependency = (
       otherDependencies
     );
 
-    log.info(
-      `Platform '${platform}' module ${
+    logger.success(
+      `${getPlatformName(platform)} module "${
         dependency.name
-      } has been successfully unlinked`
+      }" has been successfully unlinked`
     );
   });
 };
@@ -85,7 +87,7 @@ function unlink(args: Array<string>, ctx: ContextT) {
   try {
     platforms = getPlatforms(ctx.root);
   } catch (err) {
-    log.error(
+    logger.error(
       "No package.json found. Are you sure it's a React Native project?"
     );
     return Promise.reject(err);
@@ -101,13 +103,12 @@ function unlink(args: Array<string>, ctx: ContextT) {
     const idx = allDependencies.findIndex(p => p.name === packageName);
 
     if (idx === -1) {
-      throw new Error(`Project ${packageName} is not a react-native library`);
+      throw new Error(`Project "${packageName}" is not a react-native library`);
     }
 
     otherDependencies = [...allDependencies];
     dependency = otherDependencies.splice(idx, 1)[0]; // eslint-disable-line prefer-destructuring
   } catch (err) {
-    log.warn(err.message);
     return Promise.reject(err);
   }
 
@@ -148,17 +149,17 @@ function unlink(args: Array<string>, ctx: ContextT) {
           return;
         }
 
-        log.info(`Unlinking assets from ${platform} project`);
+        logger.info(`Unlinking assets from ${platform} project`);
         // $FlowFixMe: We check for platorm existence on line 150
         linkConfig.unlinkAssets(assets, project[platform]);
       });
 
-      log.info(
+      logger.info(
         `${packageName} assets has been successfully unlinked from your project`
       );
     })
     .catch(err => {
-      log.error(
+      logger.error(
         `It seems something went wrong while unlinking. Error:\n${err.message}`
       );
       throw err;

--- a/packages/cli/src/runAndroid/tryLaunchAppOnDevice.js
+++ b/packages/cli/src/runAndroid/tryLaunchAppOnDevice.js
@@ -15,7 +15,7 @@ function tryLaunchAppOnDevice(
   packageNameWithSuffix: string,
   packageName: string,
   adbPath: string,
-  mainActivity: *
+  mainActivity: string
 ) {
   try {
     const adbArgs = [

--- a/packages/cli/src/server/runServer.js
+++ b/packages/cli/src/server/runServer.js
@@ -40,7 +40,7 @@ export type Args = {|
   config?: string,
 |};
 
-async function runServer(argv: *, ctx: ContextT, args: Args) {
+async function runServer(argv: Array<string>, ctx: ContextT, args: Args) {
   const terminal = new Terminal(process.stdout);
   const ReporterImpl = getReporterImpl(args.customLogReporterPath || null);
   const reporter = new ReporterImpl(terminal);
@@ -106,7 +106,6 @@ function getReporterImpl(customLogReporterPath: ?string) {
   try {
     // First we let require resolve it, so we can require packages in node_modules
     // as expected. eg: require('my-package/reporter');
-    /* $FlowFixMe: can't type dynamic require */
     return require(customLogReporterPath);
   } catch (e) {
     if (e.code !== 'MODULE_NOT_FOUND') {
@@ -114,7 +113,6 @@ function getReporterImpl(customLogReporterPath: ?string) {
     }
     // If that doesn't work, then we next try relative to the cwd, eg:
     // require('./reporter');
-    /* $FlowFixMe: can't type dynamic require */
     return require(path.resolve(customLogReporterPath));
   }
 }

--- a/packages/cli/src/upgrade/upgrade.js
+++ b/packages/cli/src/upgrade/upgrade.js
@@ -19,7 +19,7 @@ import copyProjectTemplateAndReplace from '../generator/copyProjectTemplateAndRe
  * Migrate application to a new version of React Native.
  * See http://facebook.github.io/react-native/docs/upgrading.html
  */
-function validateAndUpgrade(argv: *, ctx: ContextT) {
+function validateAndUpgrade(argv: Array<string>, ctx: ContextT) {
   const projectDir = ctx.root;
 
   const packageJSON = JSON.parse(

--- a/packages/cli/src/util/assertRequiredOptions.js
+++ b/packages/cli/src/util/assertRequiredOptions.js
@@ -25,7 +25,7 @@ export default function assertRequiredOptions(options, passedOptions) {
 
     if (!passedOptions[name]) {
       // Provide commander.js like error message
-      throw new Error(`error: option '${option.long}' missing`);
+      throw new Error(`Option "${option.long}" is missing`);
     }
   });
 }

--- a/packages/cli/src/util/loadMetroConfig.js
+++ b/packages/cli/src/util/loadMetroConfig.js
@@ -71,7 +71,7 @@ export const getDefaultConfig = (ctx: ContextT) => {
   };
 };
 
-export type ConfigOptionsT = {
+export type ConfigOptionsT = {|
   maxWorkers?: number,
   port?: number,
   resetCache?: boolean,
@@ -79,7 +79,7 @@ export type ConfigOptionsT = {
   sourceExts?: string[],
   reporter?: any, // eslint-disable-line flowtype/no-weak-types
   config?: string,
-};
+|};
 
 /**
  * Loads Metro Config and applies `options` on top of the resolved config.
@@ -88,6 +88,7 @@ export type ConfigOptionsT = {
  */
 export default async function load(
   ctx: ContextT,
+  // $FlowFixMe - troubles with empty object being inexact
   options?: ConfigOptionsT = {}
 ): Promise<ConfigT> {
   const defaultConfig = getDefaultConfig(ctx);

--- a/packages/cli/src/util/logger.js
+++ b/packages/cli/src/util/logger.js
@@ -8,6 +8,10 @@ const SEPARATOR = ', ';
 const formatMessages = (messages: Array<string>) =>
   chalk.reset(messages.join(SEPARATOR));
 
+const success = (...messages: Array<string>) => {
+  console.log(`${chalk.green.bold('success')} ${formatMessages(messages)}`);
+};
+
 const info = (...messages: Array<string>) => {
   console.log(`${chalk.cyan.bold('info')} ${formatMessages(messages)}`);
 };
@@ -29,6 +33,7 @@ const log = (...messages: Array<string>) => {
 };
 
 export default {
+  success,
   info,
   warn,
   error,


### PR DESCRIPTION
Summary:
---------

Attempt No. 2 after https://github.com/react-native-community/react-native-cli/pull/178. Turned out I passed empty array as `platforms` argument to link, while I should pass `undefined`. We could actually add `--platforms` support to `install`/`uninstall` now, what do you think?

Test Plan:
----------

Uninstalling:

<img width="677" alt="screenshot 2019-02-19 at 13 42 54" src="https://user-images.githubusercontent.com/5106466/53015940-8ed51980-344c-11e9-9f22-0406c468a10d.png">

Installing: 

<img width="668" alt="screenshot 2019-02-19 at 13 43 02" src="https://user-images.githubusercontent.com/5106466/53015941-8ed51980-344c-11e9-8556-a6350f05536f.png">

