### PR TITLE
Server should listening for all incoming requests by default

### DIFF
--- a/packages/cli/src/link/link.js
+++ b/packages/cli/src/link/link.js
@@ -74,7 +74,7 @@ function link([rawPackageName]: Array<string>, ctx: ContextT, opts: FlagsType) {
     () => promisify(dependencyConfig.commands.prelink || commandStub),
     () => linkDependency(platforms, project, dependencyConfig),
     () => promisify(dependencyConfig.commands.postlink || commandStub),
-    () => linkAssets(platforms, project, dependencyConfig),
+    () => linkAssets(platforms, project, dependencyConfig.assets),
   ];
 
   return promiseWaterfall(tasks).catch(err => {

--- a/packages/cli/src/link/linkAll.js
+++ b/packages/cli/src/link/linkAll.js
@@ -13,7 +13,8 @@ import promisify from './promisify';
 import linkAssets from './linkAssets';
 import linkDependency from './linkDependency';
 
-const dedupeAssets = assets => uniqBy(assets, asset => path.basename(asset));
+const dedupeAssets = (assets: Array<string>): Array<string> =>
+  uniqBy(assets, asset => path.basename(asset));
 
 function linkAll(
   context: ContextT,

--- a/packages/cli/src/link/linkAssets.js
+++ b/packages/cli/src/link/linkAssets.js
@@ -1,20 +1,16 @@
 // @flow
 
 import { isEmpty } from 'lodash';
-import type {
-  PlatformsT,
-  ProjectConfigT,
-  DependenciesConfig,
-} from '../core/types.flow';
+import type { PlatformsT, ProjectConfigT } from '../core/types.flow';
 
 import logger from '../util/logger';
 
 const linkAssets = (
   platforms: PlatformsT,
   project: ProjectConfigT,
-  dependency: DependenciesConfig
+  assets: Array<string>
 ) => {
-  if (isEmpty(dependency.assets)) {
+  if (isEmpty(assets)) {
     return;
   }
 
@@ -30,7 +26,7 @@ const linkAssets = (
 
     logger.info(`Linking assets to ${platform} project`);
     // $FlowFixMe: We check for existence of project[platform]
-    linkConfig.copyAssets(dependency.assets, project[platform]);
+    linkConfig.copyAssets(assets, project[platform]);
   });
 
   logger.info('Assets have been successfully linked to your project');

--- a/packages/cli/src/server/server.js
+++ b/packages/cli/src/server/server.js
@@ -22,7 +22,7 @@ export default {
     },
     {
       command: '--host [string]',
-      default: 'localhost',
+      default: '',
     },
     {
       command: '--watchFolders [list]',


### PR DESCRIPTION
Summary:
---------

In previous versions, the default "host" parameter was empty. I didn't dig to much into it, but I assume it transformed to the equivalent of starting a server listening for `0.0.0.0`. Now the default value is `localhost`, which in my case do not allow me establish a connection between Metro ( on my laptop ) and my external device ( an iPad ), even if they are on the same network. This do not allow me to Reload or debug remotely. 

Test Plan:
----------

- Run the Metro Bundler on your machine.
- Try to connect to it from any other device on the same network ( i.e, 192.168.0.9:8081 ), which will refuse the connection.
- Try to run the Metro Bundler again, but this time with `--host 0.0.0.0`, and try to connect again from an external device. Now it should connect. That should be the default behaviour.