### PR TITLE
fix: server should listening for all incoming requests by default

### DIFF
--- a/packages/cli/src/server/server.js
+++ b/packages/cli/src/server/server.js
@@ -22,7 +22,7 @@ export default {
     },
     {
       command: '--host [string]',
-      default: 'localhost',
+      default: '',
     },
     {
       command: '--watchFolders [list]',

--- a/packages/cli/src/server/server.js
+++ b/packages/cli/src/server/server.js
@@ -22,7 +22,7 @@ export default {
     },
     {
       command: '--host [string]',
-      default: '',
+      default: '0.0.0.0',
     },
     {
       command: '--watchFolders [list]',


### PR DESCRIPTION
Summary:
---------

In previous versions, the default "host" parameter was empty. I didn't dig to much into it, but I assume it transformed to the equivalent of starting a server listening for `0.0.0.0`. Now the default value is `localhost`, which in my case do not allow me establish a connection between Metro ( on my laptop ) and my external device ( an iPad ), even if they are on the same network. This do not allow me to Reload or debug remotely. 

Test Plan:
----------

- Run the Metro Bundler on your machine.
- Try to connect to it from any other device on the same network ( i.e, 192.168.0.9:8081 ), which will refuse the connection.
- Try to run the Metro Bundler again, but this time with `--host 0.0.0.0`, and try to connect again from an external device. Now it should connect. That should be the default behaviour.

Introduced by: https://github.com/react-native-community/react-native-cli/pull/28
I haven't checked if `launchDevTools` ( https://github.com/react-native-community/react-native-cli/pull/28/files#diff-c4b441f65f8822889a54a29511244eefR67 ) will break with this PR. Possibly `0.0.0.0` is a better choice as default value?