### PR TITLE
fix: install template dev dependencies as such

### DIFF
--- a/packages/cli/src/generator/templates.js
+++ b/packages/cli/src/generator/templates.js
@@ -157,7 +157,7 @@ function installTemplateDevDependencies(templatePath, destinationRoot) {
   const dependenciesToInstall = Object.keys(dependencies).map(
     depName => `${depName}@${dependencies[depName]}`
   );
-  new PackageManager({ projectDir: destinationRoot }).install(
+  new PackageManager({ projectDir: destinationRoot }).installDev(
     dependenciesToInstall
   );
 }


### PR DESCRIPTION
Hi everyone,

This pull request contains a small fix for the issue that caused template dev dependencies to be installed as regular dependencies.


Test Plan:
----------

Went with the guide in the CONTRIBUTION.md document, installed Verdaccio, released a new version of React Native to it and used it to create a new project with a template that has dev dependencies to check if the dependencies are still being installed as regular dependencies.
