### PR TITLE
Correct paths for eject command

### DIFF
--- a/packages/cli/src/commands/eject/eject.js
+++ b/packages/cli/src/commands/eject/eject.js
@@ -71,15 +71,7 @@ function eject() {
   if (!doesIOSExist) {
     logger.info('Generating the iOS folder.');
     copyProjectTemplateAndReplace(
-      path.resolve(
-        'node_modules',
-        'react-native',
-        '@react-native-community',
-        'cli',
-        'templates',
-        'HelloWorld',
-        'ios',
-      ),
+      path.resolve('node_modules', 'react-native', 'template', 'ios'),
       path.resolve('ios'),
       appName,
       templateOptions,
@@ -89,15 +81,7 @@ function eject() {
   if (!doesAndroidExist) {
     logger.info('Generating the Android folder.');
     copyProjectTemplateAndReplace(
-      path.resolve(
-        'node_modules',
-        'react-native',
-        '@react-native-community',
-        'cli',
-        'templates',
-        'HelloWorld',
-        'android',
-      ),
+      path.resolve('node_modules', 'react-native', 'template', 'android'),
       path.resolve('android'),
       appName,
       templateOptions,


### PR DESCRIPTION
Summary:
---------

`eject` had wrong paths (pointing to old RN directories), so this PR fixes that.

Fixes #207 	

Test Plan:
----------

1. Init new project RN 0.59+
2. Remove `android` and/or `ios`
3. Use the `eject` command to generate ios/android projects
