### PR TITLE
chore: remove unnecessary option for a command

### DIFF
--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -84,7 +84,7 @@ const addCommand = (command: CommandT, ctx: ContextT) => {
   const options = command.options || [];
 
   const cmd = commander
-    .command(command.name, undefined, {noHelp: !command.description})
+    .command(command.name)
     .description(command.description)
     .action(function handleAction(...args) {
       const passedOptions = this.opts();


### PR DESCRIPTION
Summary:
---------

Fixes #214 

`noHelp` doesn't work because we override `printHelpInformation` and we need to handle `description` (that can be undefined) manually
