### PR TITLE
chore: remove unnecessary checks for react peer dep

### DIFF
--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -49,22 +49,8 @@ function init(projectDir, argsOrName) {
  * @param options Command line arguments parsed by minimist.
  */
 function generateProject(destinationRoot, newProjectName, options) {
-  const reactNativePackageJson = require('react-native/package.json');
-  const {peerDependencies} = reactNativePackageJson;
-  if (!peerDependencies) {
-    logger.error(
-      "Missing React peer dependency in React Native's package.json. Aborting.",
-    );
-    return;
-  }
-
-  const reactVersion = peerDependencies.react;
-  if (!reactVersion) {
-    logger.error(
-      "Missing React peer dependency in React Native's package.json. Aborting.",
-    );
-    return;
-  }
+  const pkgJson = require('react-native/package.json');
+  const reactVersion = pkgJson.peerDependencies.react;
 
   const packageManager = new PackageManager({
     projectDir: destinationRoot,


### PR DESCRIPTION
Summary:
---------

I'm aware @Esemesek works on revamping `init`, but in the meantime we can remove these extra checks.
Fixes https://github.com/react-native-community/react-native-cli/issues/14.

Test Plan:
----------

No test plan
