### PR TITLE
docs: fix verdaccio command in contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ yarn global add verdaccio
 ```
 * Run verdaccio
 ```sh
-yarn verdaccio
+verdaccio
 ```
 * Set npm registry to `verdaccio` proxy server
 ```sh


### PR DESCRIPTION
Summary:
---------

Because `verdaccio` was not installed locally to the directory but globally (in previous step), through `yarn global`, the `verdaccio` command should not be prefixed by `yarn`, otherwise resulting in an error.