### PR TITLE
fix: path to InitializeCore module in default metro config

### DIFF
--- a/packages/cli/src/tools/loadMetroConfig.js
+++ b/packages/cli/src/tools/loadMetroConfig.js
@@ -48,7 +48,7 @@ export const getDefaultConfig = (ctx: ContextT) => {
     serializer: {
       getModulesRunBeforeMainModule: () => [
         require.resolve(
-          path.join(ctx.reactNativePath, 'Libraries/tools/InitializeCore'),
+          path.join(ctx.reactNativePath, 'Libraries/Core/InitializeCore'),
         ),
       ],
       getPolyfills: () =>


### PR DESCRIPTION
Summary:
---------

Fix path to React Native `InitializeCore` module in default metro config.
For some reason, this path was modified when moving the `loadMetroConfig.js` file in new `tools` directory.
In current released version (v1.3.2) of the cli, the path is the correct one, as seen in the [loadMetroConfig.js](https://github.com/react-native-community/react-native-cli/blob/%40react-native-community/cli%401.3.2/packages/cli/src/util/loadMetroConfig.js#L52) of v1.3.2.

Test Plan:
----------

Was trying out `react-native run-ios` / `run-android` commands, after a fresh `react-native init` with current master branch of the cli, and was facing following metro bundler error:

```
error: bundling failed: Error: Cannot find module '/Users/blemair/Code/foo/node_modules/react-native/Libraries/tools/InitializeCore'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:580:15)
    at Function.resolve (internal/modules/cjs/helpers.js:30:19)
    at Object.getModulesRunBeforeMainModule (/Users/blemair/Code/foo/node_modules/@react-native-community/cli/build/tools/loadMetroConfig.js:80:53)
[...]
```

After fixing the path, bundling error was gone.