### PR TITLE
Fix Android unlink regression

### DIFF
--- a/packages/cli/src/commands/link/__tests__/android/makeBuildPatch-test.js
+++ b/packages/cli/src/commands/link/__tests__/android/makeBuildPatch-test.js
@@ -10,6 +10,14 @@
 
 import makeBuildPatch from '../../android/patches/makeBuildPatch';
 import normalizeProjectName from '../../android/patches/normalizeProjectName';
+import path from 'path';
+
+const projectConfig = {
+  buildGradlePath: path.join(
+    __dirname,
+    '../../__fixtures__/android/patchedBuild.gradle',
+  ),
+};
 
 const name = 'test';
 const scopedName = '@scoped/test';
@@ -31,6 +39,23 @@ describe('makeBuildPatch', () => {
     const {installPattern} = makeBuildPatch(name);
     expect(installPattern.toString()).toEqual(expect.stringContaining(name));
   });
+
+  test.each([
+    ['test-impl', "    implementation project(':test-impl')\n"],
+    ['test-compile', "    compile project(':test-compile')\n"],
+    ['test-api', "    api project(':test-api')\n"],
+    [
+      'test-not-there-yet',
+      "    implementation project(':test-not-there-yet')\n",
+    ],
+  ])(
+    'properly detects the patch string of project %p in build.gradle',
+    (project, projectPatchString) => {
+      expect(makeBuildPatch(project, projectConfig.buildGradlePath).patch).toBe(
+        projectPatchString,
+      );
+    },
+  );
 });
 
 describe('makeBuildPatchWithScopedPackage', () => {

--- a/packages/cli/src/commands/link/android/patches/makeBuildPatch.js
+++ b/packages/cli/src/commands/link/android/patches/makeBuildPatch.js
@@ -13,7 +13,7 @@ import normalizeProjectName from './normalizeProjectName';
 export default function makeBuildPatch(name, buildGradlePath) {
   const normalizedProjectName = normalizeProjectName(name);
   const installPattern = new RegExp(
-    `(implementation|api|compile)\\w*\\s*\\(*project\\(['"]:${normalizedProjectName}['"]\\)`,
+    `(implementation|api|compile)\\w*\\s*\\(*project\\s*\\(['"]:${normalizedProjectName}['"]\\)`,
   );
 
   return {
@@ -34,7 +34,7 @@ function makePatchString(normalizedProjectName, buildGradlePath) {
   const depTypes = ['compile', 'api', 'implementation'];
   for (const type of depTypes) {
     const depPattern = new RegExp(
-      `(${type})\\w*\\s*\\(*project\\(['"]:${normalizedProjectName}['"]\\)`,
+      `(${type})\\w*\\s*\\(*project\\s*\\(['"]:${normalizedProjectName}['"]\\)`,
     );
 
     if (depPattern.test(buildGradle)) {

--- a/packages/cli/src/commands/link/android/patches/makeBuildPatch.js
+++ b/packages/cli/src/commands/link/android/patches/makeBuildPatch.js
@@ -7,9 +7,10 @@
  * @format
  */
 
+import fs from 'fs';
 import normalizeProjectName from './normalizeProjectName';
 
-export default function makeBuildPatch(name) {
+export default function makeBuildPatch(name, buildGradlePath) {
   const normalizedProjectName = normalizeProjectName(name);
   const installPattern = new RegExp(
     `(implementation|api|compile)\\w*\\s*\\(*project\\(['"]:${normalizedProjectName}['"]\\)`,
@@ -18,6 +19,28 @@ export default function makeBuildPatch(name) {
   return {
     installPattern,
     pattern: /[^ \t]dependencies {(\r\n|\n)/,
-    patch: `    implementation project(':${normalizedProjectName}')\n`,
+    patch: makePatchString(normalizedProjectName, buildGradlePath),
   };
+}
+
+function makePatchString(normalizedProjectName, buildGradlePath) {
+  const defaultPatchString = `    implementation project(':${normalizedProjectName}')\n`;
+  if (!buildGradlePath) {
+    return defaultPatchString;
+  }
+
+  const buildGradle = fs.readFileSync(buildGradlePath);
+
+  const depTypes = ['compile', 'api', 'implementation'];
+  for (const type of depTypes) {
+    const depPattern = new RegExp(
+      `(${type})\\w*\\s*\\(*project\\(['"]:${normalizedProjectName}['"]\\)`,
+    );
+
+    if (depPattern.test(buildGradle)) {
+      return `    ${type} project(':${normalizedProjectName}')\n`;
+    }
+  }
+
+  return defaultPatchString;
 }

--- a/packages/cli/src/commands/link/android/patches/makeBuildPatch.js
+++ b/packages/cli/src/commands/link/android/patches/makeBuildPatch.js
@@ -10,12 +10,12 @@
 import fs from 'fs';
 import normalizeProjectName from './normalizeProjectName';
 
-const depTypes = ['compile', 'api', 'implementation'];
+const depConfigs = ['compile', 'api', 'implementation'];
 
 export default function makeBuildPatch(name, buildGradlePath) {
   const normalizedProjectName = normalizeProjectName(name);
   const installPattern = new RegExp(
-    buildDepRegExp(normalizedProjectName, ...depTypes),
+    buildDepRegExp(normalizedProjectName, ...depConfigs),
   );
 
   return {
@@ -33,17 +33,19 @@ function makePatchString(normalizedProjectName, buildGradlePath) {
 
   const buildGradle = fs.readFileSync(buildGradlePath);
 
-  for (const type of depTypes) {
-    const depPattern = new RegExp(buildDepRegExp(normalizedProjectName, type));
+  for (const config of depConfigs) {
+    const depPattern = new RegExp(
+      buildDepRegExp(normalizedProjectName, config),
+    );
     if (depPattern.test(buildGradle)) {
-      return `    ${type} project(':${normalizedProjectName}')\n`;
+      return `    ${config} project(':${normalizedProjectName}')\n`;
     }
   }
 
   return defaultPatchString;
 }
 
-function buildDepRegExp(normalizedProjectName, ...types) {
-  const orTypes = types.join('|');
-  return `(${orTypes})\\w*\\s*\\(*project\\s*\\(['"]:${normalizedProjectName}['"]\\)`;
+function buildDepRegExp(normalizedProjectName, ...configs) {
+  const orConfigs = configs.join('|');
+  return `(${orConfigs})\\w*\\s*\\(*project\\s*\\(['"]:${normalizedProjectName}['"]\\)`;
 }

--- a/packages/cli/src/commands/link/android/unregisterNativeModule.js
+++ b/packages/cli/src/commands/link/android/unregisterNativeModule.js
@@ -22,7 +22,7 @@ export default function unregisterNativeAndroidModule(
   androidConfig,
   projectConfig,
 ) {
-  const buildPatch = makeBuildPatch(name);
+  const buildPatch = makeBuildPatch(name, projectConfig.buildGradlePath);
   const strings = fs.readFileSync(projectConfig.stringsPath, 'utf8');
   const params = {};
 


### PR DESCRIPTION
Summary:
---------
This PR fixes a regression introduced in https://github.com/react-native-community/react-native-cli/commit/c6c34a2a6e0d5898a62bc10b7c2936cadba3e071 where only `implementation` type dependencies would be unlinked correctly. Previously linked `compile` dependencies would not be fully unlinked. This issue has been discussed also in #43, #81 and [here](https://github.com/facebook/react-native/pull/21043).

This PR augments the Android `makeBuildPatch` to accept the path of the Gradle build configuration as a second parameter so that the correct patch string can be detected instead of returning the hardcoded `implementation` variant.

The path to the Gradle file is optional and if none is provided, `makeBuildPatch` will return the default  `implementation` patch string as it has always been since the introduction of the regression. This behavior is preferred since this feature is only needed when unlinking and other files like `registerNativeModule` used by `link` don't need to be edited.

An additional test is added to verify the detection of the patch string used in the Gradle build file.


<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------
Try unlinking any `compile`, `implementation` or `api` dependency.
<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->


CC @grabbou 