### PR TITLE
fix: re-export findPlugins under cli/core for backcompat with RN 0.59

### DIFF
--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -17,6 +17,7 @@ import {getCommands} from './commands';
 import init from './commands/init/init';
 import assertRequiredOptions from './tools/assertRequiredOptions';
 import logger from './tools/logger';
+import findPlugins from './tools/findPlugins';
 import pkgJson from '../package.json';
 
 commander
@@ -202,4 +203,4 @@ export default {
   init,
 };
 
-// export { run, init };
+export {run, init, findPlugins};

--- a/packages/cli/src/core/findPlugins.js
+++ b/packages/cli/src/core/findPlugins.js
@@ -1,0 +1,12 @@
+/**
+ * This file exists only because RN 0.59.0 stable consumes it and we don't want
+ * to introduce a breaking change.
+ * See consumer: https://github.com/facebook/react-native/blob/7c73f2bb5a0f97902f469bc043681e79e161aac3/jest/hasteImpl.js#L28
+ * @todo: remove in 2.0
+ *
+ * @flow
+ */
+
+import findPlugins from '../tools/findPlugins';
+
+export default findPlugins;


### PR DESCRIPTION
Summary:
---------

[hasteImpl](https://github.com/facebook/react-native/blob/7c73f2bb5a0f97902f469bc043681e79e161aac3/jest/hasteImpl.js#L28) in RN 0.59 still uses private APIs that recently changed (files were moved around).
This is the only way we can easily iterate on 1.x release without breaking RN stability.

Also exported `findPlugins` from `cliEntry` so RN is able to consume it properly.

Test Plan:
----------

None
