### PR TITLE
fix: debugger-ui incorrect path

### DIFF
--- a/packages/cli/src/commands/server/middleware/MiddlewareManager.js
+++ b/packages/cli/src/commands/server/middleware/MiddlewareManager.js
@@ -42,7 +42,7 @@ export default class MiddlewareManager {
   options: Options;
 
   constructor(options: Options) {
-    const debuggerUIFolder = path.join(__dirname, '..', 'util', 'debugger-ui');
+    const debuggerUIFolder = path.join(__dirname, '..', 'debugger-ui');
 
     this.options = options;
     this.app = connect()


### PR DESCRIPTION
Summary:
---------

Missed this one while moving files around in https://github.com/react-native-community/react-native-cli/pull/201.
Fixes https://github.com/react-native-community/react-native-cli/issues/225


Test Plan:
----------

Verified locally on a clean project.
