### PR TITLE
fix: set proper peer dependencies

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,7 +54,7 @@
     "xmldoc": "^0.4.0"
   },
   "peerDependencies": {
-    "react-native": "^0.57.0"
+    "react-native": "^0.59.0"
   },
   "devDependencies": {
     "snapshot-diff": "^0.5.0"


### PR DESCRIPTION
Summary:
---------

CLI v1.x is designed to work with ^0.59.0. 


Test Plan:
----------

No peer dep warning
