### PR TITLE
Add `eslint` to react native project template.

### DIFF
--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -71,6 +71,8 @@ function generateProject(destinationRoot, newProjectName, options) {
   packageManager.installDev([
     '@babel/core',
     '@babel/runtime',
+    '@react-native-community/eslint-config',
+    'eslint',
     'jest',
     'babel-jest',
     'metro-react-native-babel-preset',
@@ -89,6 +91,7 @@ function addJestToPackageJson(destinationRoot) {
   const packageJSON = JSON.parse(fs.readFileSync(packageJSONPath));
 
   packageJSON.scripts.test = 'jest';
+  packageJSON.scripts.lint = 'eslint .';
   packageJSON.jest = {
     preset: 'react-native',
   };

--- a/packages/cli/src/tools/generator/copyProjectTemplateAndReplace.js
+++ b/packages/cli/src/tools/generator/copyProjectTemplateAndReplace.js
@@ -127,7 +127,7 @@ function translateFilePath(filePath) {
     .replace('_gitignore', '.gitignore')
     .replace('_gitattributes', '.gitattributes')
     .replace('_babelrc', '.babelrc')
-    .replace('_eslintrc', '.eslintrc')
+    .replace('_eslintrc.js', '.eslintrc.js')
     .replace('_flowconfig', '.flowconfig')
     .replace('_buckconfig', '.buckconfig')
     .replace('_watchmanconfig', '.watchmanconfig');

--- a/packages/cli/src/tools/generator/copyProjectTemplateAndReplace.js
+++ b/packages/cli/src/tools/generator/copyProjectTemplateAndReplace.js
@@ -127,6 +127,7 @@ function translateFilePath(filePath) {
     .replace('_gitignore', '.gitignore')
     .replace('_gitattributes', '.gitattributes')
     .replace('_babelrc', '.babelrc')
+    .replace('_eslintrc', '.eslintrc')
     .replace('_flowconfig', '.flowconfig')
     .replace('_buckconfig', '.buckconfig')
     .replace('_watchmanconfig', '.watchmanconfig');


### PR DESCRIPTION
Summary:
---------
The goal of this PR is to enable `eslint` checks in the projects generated by `react-native init` command. I added `eslint` and `@react-native-community/eslint-config` as dependencies. Also there is a new script in generated `package.json` called `lint`.

PR to update template in `react-native` repo: https://github.com/facebook/react-native/pull/23901

Test Plan:
----------
Follow setup from https://github.com/react-native-community/react-native-cli/blob/master/CONTRIBUTING.md
```bash
react-native init TestProject --template eslint-integration
cd TestProject && yarn lint
```

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
