### PR TITLE
fix: linking assets on Android

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,6 +28,7 @@
     "errorhandler": "^1.5.0",
     "escape-string-regexp": "^1.0.5",
     "execa": "^1.0.0",
+    "fs-extra": "^7.0.1",
     "glob": "^7.1.1",
     "graceful-fs": "^4.1.3",
     "inquirer": "^3.0.6",

--- a/packages/cli/src/commands/link/android/copyAssets.js
+++ b/packages/cli/src/commands/link/android/copyAssets.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import fs from 'fs';
+import fs from 'fs-extra';
 import path from 'path';
 import groupFilesByType from '../groupFilesByType';
 
@@ -23,10 +23,10 @@ export default function copyAssetsAndroid(
 ) {
   const assets = groupFilesByType(files);
 
-  (assets.font || []).forEach(asset =>
-    fs.copyFileSync(
-      asset,
-      path.join(project.assetsPath, 'fonts', path.basename(asset)),
-    ),
-  );
+  (assets.font || []).forEach(asset => {
+    const fontsDir = path.join(project.assetsPath, 'fonts');
+    // @todo: replace with fs.mkdirSync(path, {recursive}) + fs.copyFileSync
+    // and get rid of fs-extra once we move to Node 10
+    fs.copySync(asset, path.join(fontsDir, path.basename(asset)));
+  });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3518,7 +3518,7 @@ fs-extra@^1.0.0:
     jsonfile "^2.1.0"
     klaw "^1.0.0"
 
-fs-extra@^7.0.0:
+fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==


### PR DESCRIPTION
Summary:
---------

Fixes https://github.com/react-native-community/react-native-cli/issues/228 introduced by removing `fs-extra`. Brought it back and left a todo when we move to Node 10.

Test Plan:
----------

Green CI (need to covert this in e2e tests once we set them up)
