### PR TITLE
fix: refine upgrade error handling

### DIFF
--- a/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
+++ b/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
@@ -134,6 +134,7 @@ $ execa git apply --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way
 info Applying diff...
 $ execa git apply tmp-upgrade-rn.patch --exclude=package.json -p2 --3way
 [fs] unlink tmp-upgrade-rn.patch
+$ execa git status -s
 info Installing \\"react-native@0.58.4\\" and its peer dependencies...
 $ execa npm info react-native@0.58.4 peerDependencies --json
 $ yarn add react-native@0.58.4 react@16.6.3
@@ -185,11 +186,13 @@ info Applying diff (excluding: package.json, .flowconfig)...
 $ execa git apply tmp-upgrade-rn.patch --exclude=package.json --exclude=.flowconfig -p2 --3way
 [2merror: .flowconfig: does not exist in index[22m
 error Automatically applying diff failed
-info Here's the diff we tried to apply: [4m[2mhttps://github.com/react-native-community/rn-diff-purge/compare/version/0.57.8...version/0.58.4[22m[24m
 [fs] unlink tmp-upgrade-rn.patch
 $ execa git status -s
-error Patch failed to apply for unknown reason. Please fall back to manual way of upgrading using links above
+error Patch failed to apply for unknown reason. Please fall back to manual way of upgrading
 $ execa git remote remove tmp-rn-diff-purge
-warn Please run \\"git diff\\" to review the conflicts and resolve them. You may find release notes helpful: [4m[2mhttps://github.com/facebook/react-native/releases/tag/v0.58.4[22m[24m"
+info You may find these resources helpful:
+• Release notes: [4m[2mhttps://github.com/facebook/react-native/releases/tag/v0.58.4[22m[24m
+• Comparison between versions: [4m[2mhttps://github.com/react-native-community/rn-diff-purge/compare/version/0.57.8..version/0.58.4[22m[24m
+• Git diff: [4m[2mhttps://github.com/react-native-community/rn-diff-purge/compare/version/0.57.8..version/0.58.4.diff[22m[24m"
 `);
 });

--- a/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
+++ b/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
@@ -112,8 +112,7 @@ test('fetches empty patch and installs deps', async () => {
   expect(flushOutput()).toMatchInlineSnapshot(`
 "info Fetching diff between v0.57.8 and v0.58.4...
 info Diff has no changes to apply, proceeding further
-warn Continuing after failure. Most of the files are upgraded but you will need to deal with some conflicts manually
-info Installing react-native@0.58.4 and its peer dependencies...
+info Installing \\"react-native@0.58.4\\" and its peer dependencies...
 $ execa npm info react-native@0.58.4 peerDependencies --json
 $ yarn add react-native@0.58.4 react@16.6.3
 $ execa git add package.json
@@ -135,7 +134,7 @@ $ execa git apply --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way
 info Applying diff...
 $ execa git apply tmp-upgrade-rn.patch --exclude=package.json -p2 --3way
 [fs] unlink tmp-upgrade-rn.patch
-info Installing react-native@0.58.4 and its peer dependencies...
+info Installing \\"react-native@0.58.4\\" and its peer dependencies...
 $ execa npm info react-native@0.58.4 peerDependencies --json
 $ yarn add react-native@0.58.4 react@16.6.3
 $ execa git add package.json
@@ -186,19 +185,11 @@ info Applying diff (excluding: package.json, .flowconfig)...
 $ execa git apply tmp-upgrade-rn.patch --exclude=package.json --exclude=.flowconfig -p2 --3way
 [2merror: .flowconfig: does not exist in index[22m
 error Automatically applying diff failed
-info Here's the diff we tried to apply: https://github.com/react-native-community/rn-diff-purge/compare/version/0.57.8...version/0.58.4
-info You may find release notes helpful: https://github.com/facebook/react-native/releases/tag/v0.58.4
+info Here's the diff we tried to apply: [4m[2mhttps://github.com/react-native-community/rn-diff-purge/compare/version/0.57.8...version/0.58.4[22m[24m
 [fs] unlink tmp-upgrade-rn.patch
-warn Continuing after failure. Most of the files are upgraded but you will need to deal with some conflicts manually
-info Installing react-native@0.58.4 and its peer dependencies...
-$ execa npm info react-native@0.58.4 peerDependencies --json
-$ yarn add react-native@0.58.4 react@16.6.3
-$ execa git add package.json
-$ execa git add yarn.lock
-$ execa git add package-lock.json
-info Running \\"git status\\" to check what changed...
-$ execa git status
+$ execa git status -s
+error Patch failed to apply for unknown reason. Please fall back to manual way of upgrading using links above
 $ execa git remote remove tmp-rn-diff-purge
-warn Please run \\"git diff\\" to review the conflicts and resolve them"
+warn Please run \\"git diff\\" to review the conflicts and resolve them. You may find release notes helpful: [4m[2mhttps://github.com/facebook/react-native/releases/tag/v0.58.4[22m[24m"
 `);
 });

--- a/packages/cli/src/commands/upgrade/upgrade.js
+++ b/packages/cli/src/commands/upgrade/upgrade.js
@@ -104,14 +104,9 @@ const getVersionToUpgradeTo = async (argv, currentVersion, projectDir) => {
   return newVersion;
 };
 
-const installDeps = async (newVersion, projectDir, patchSuccess) => {
-  if (!patchSuccess) {
-    logger.warn(
-      'Continuing after failure. Most of the files are upgraded but you will need to deal with some conflicts manually',
-    );
-  }
+const installDeps = async (newVersion, projectDir) => {
   logger.info(
-    `Installing react-native@${newVersion} and its peer dependencies...`,
+    `Installing "react-native@${newVersion}" and its peer dependencies...`,
   );
   const peerDeps = await getRNPeerDeps(newVersion);
   const pm = new PackageManager({projectDir});
@@ -171,10 +166,9 @@ const applyPatch = async (
     }
     logger.error('Automatically applying diff failed');
     logger.info(
-      `Here's the diff we tried to apply: ${rnDiffPurgeUrl}/compare/version/${currentVersion}...version/${newVersion}`,
-    );
-    logger.info(
-      `You may find release notes helpful: https://github.com/facebook/react-native/releases/tag/v${newVersion}`,
+      `Here's the diff we tried to apply: ${chalk.underline.dim(
+        `${rnDiffPurgeUrl}/compare/version/${currentVersion}...version/${newVersion}`,
+      )}`,
     );
     return false;
   }
@@ -188,8 +182,7 @@ async function upgrade(argv: Array<string>, ctx: ContextT, args: FlagsT) {
   if (args.legacy) {
     return legacyUpgrade.func(argv, ctx);
   }
-  const rnDiffGitAddress =
-    'https://github.com/react-native-community/rn-diff-purge.git';
+  const rnDiffGitAddress = `${rnDiffPurgeUrl}.git`;
   const tmpRemote = 'tmp-rn-diff-purge';
   const tmpPatchFile = 'tmp-upgrade-rn.patch';
   const projectDir = ctx.root;
@@ -229,9 +222,6 @@ async function upgrade(argv: Array<string>, ctx: ContextT, args: FlagsT) {
     await execa('git', ['remote', 'add', tmpRemote, rnDiffGitAddress]);
     await execa('git', ['fetch', '--no-tags', tmpRemote]);
     patchSuccess = await applyPatch(currentVersion, newVersion, tmpPatchFile);
-    if (!patchSuccess) {
-      return;
-    }
   } catch (error) {
     throw new Error(error.stderr || error);
   } finally {
@@ -240,14 +230,32 @@ async function upgrade(argv: Array<string>, ctx: ContextT, args: FlagsT) {
     } catch (e) {
       // ignore
     }
-    await installDeps(newVersion, projectDir, patchSuccess);
-    logger.info('Running "git status" to check what changed...');
-    await execa('git', ['status'], {stdio: 'inherit'});
+    if (!patchSuccess) {
+      const {stdout} = await execa('git', ['status', '-s']);
+      if (stdout) {
+        logger.warn(
+          'Continuing after failure. Most of the files are upgraded but you will need to deal with some conflicts manually',
+        );
+        await installDeps(newVersion, projectDir);
+        logger.info('Running "git status" to check what changed...');
+        await execa('git', ['status'], {stdio: 'inherit'});
+      } else {
+        logger.error(
+          'Patch failed to apply for unknown reason. Please fall back to manual way of upgrading using links above',
+        );
+      }
+    } else {
+      await installDeps(newVersion, projectDir);
+      logger.info('Running "git status" to check what changed...');
+      await execa('git', ['status'], {stdio: 'inherit'});
+    }
     await execa('git', ['remote', 'remove', tmpRemote]);
 
     if (!patchSuccess) {
       logger.warn(
-        'Please run "git diff" to review the conflicts and resolve them',
+        `Please run "git diff" to review the conflicts and resolve them. You may find release notes helpful: ${chalk.underline.dim(
+          `https://github.com/facebook/react-native/releases/tag/v${newVersion}`,
+        )}`,
       );
       throw new Error(
         'Upgrade failed. Please see the messages above for details',


### PR DESCRIPTION
Summary:
---------

Improved error and success handling, so it accounts for https://github.com/react-native-community/react-native-cli/issues/230.

What changed:
- check if `git status -s` returns anything before saying that "most files were upgraded successfully", while they didn't
- don't incorrectly warn after empty patch 
- changed links to be underlined and dimmed
- moved "You may find release notes helpful" message with useful links to the very bottom right before failing the command


Test Plan:
----------

Updated tests, but feel free to give it a shot on any test project.

Failing to apply some changes:

<img width="890" alt="Screenshot 2019-03-14 at 10 16 09" src="https://user-images.githubusercontent.com/5106466/54344977-59ce7800-4642-11e9-864a-00efb72f7ad6.png">

Git apply fails badly:

<img width="784" alt="Screenshot 2019-03-14 at 10 16 21" src="https://user-images.githubusercontent.com/5106466/54345001-69e65780-4642-11e9-80d9-b744d0a175e1.png">
