### PR TITLE
fix: reactNativePath and projectRoot not being parsed by commander

### DIFF
--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -10,6 +10,7 @@
 import chalk from 'chalk';
 import childProcess from 'child_process';
 import commander from 'commander';
+import minimist from 'minimist';
 import path from 'path';
 import type {CommandT, ContextT} from './tools/types.flow';
 import getLegacyConfig from './tools/getLegacyConfig';
@@ -153,12 +154,19 @@ async function setupAndRun() {
     }
   }
 
-  const root = commander.projectRoot
-    ? path.resolve(commander.projectRoot)
+  /**
+   * At this point, commander arguments are not parsed yet because we need to
+   * add all the commands and their options. That's why we resort to using
+   * minimist for parsing some global options.
+   */
+  const options = minimist(process.argv.slice(2));
+
+  const root = options.projectRoot
+    ? path.resolve(options.projectRoot)
     : process.cwd();
 
-  const reactNativePath = commander.reactNativePath
-    ? path.resolve(commander.reactNativePath)
+  const reactNativePath = options.reactNativePath
+    ? path.resolve(options.reactNativePath)
     : (() => {
         try {
           return path.dirname(

--- a/yarn.lock
+++ b/yarn.lock
@@ -5695,9 +5695,14 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.1, minimist@^1.1.3:
   version "1.2.0"
   resolved "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+
+minimist@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
 minimist@~0.0.1:
   version "0.0.10"


### PR DESCRIPTION
Summary:
---------

Turns out we need `minimist` for now. Left a proper comment on why we need it.
Hopefully we'll figure out a cleaner way soon.

Test Plan:
----------

works for me
