### PR TITLE
Throw an error if an invalid platform is passed to the bundler

### DIFF
--- a/packages/cli/src/commands/bundle/buildBundle.js
+++ b/packages/cli/src/commands/bundle/buildBundle.js
@@ -32,7 +32,9 @@ async function buildBundle(
     console.log(
       chalk.red(
         [
-          `Invalid platform (${args.platform}) selected.`,
+          `Invalid platform ${
+            args.platform ? `(${args.platform}) ` : ''
+          }selected.`,
           'Available platforms are:',
           config.resolver.platforms.join(', '),
           'If you are trying to bundle for an out-of-tree platform, it may not be installed.',

--- a/packages/cli/src/commands/bundle/buildBundle.js
+++ b/packages/cli/src/commands/bundle/buildBundle.js
@@ -11,6 +11,7 @@ import Server from 'metro/src/Server';
 
 import outputBundle from 'metro/src/shared/output/bundle';
 import path from 'path';
+import chalk from 'chalk';
 import type {CommandLineArgs} from './bundleCommandLineArgs';
 import type {ContextT} from '../../tools/types.flow';
 import saveAssets from './saveAssets';
@@ -26,6 +27,20 @@ async function buildBundle(
     resetCache: args.resetCache,
     config: args.config,
   });
+
+  if (config.resolver.platforms.indexOf(args.platform) === -1) {
+    console.log(
+      chalk.red(
+        [
+          `Invalid platform (${args.platform}) selected.`,
+          'Available platforms are:',
+          config.resolver.platforms.join(', '),
+          'If you are trying to bundle for an out-of-tree platform, it may not be installed.',
+        ].join('\n'),
+      ),
+    );
+    throw new Error('Invalid platform selected.');
+  }
 
   // This is used by a bazillion of npm modules we don't control so we don't
   // have other choice than defining it as an env variable here.

--- a/packages/cli/src/commands/bundle/buildBundle.js
+++ b/packages/cli/src/commands/bundle/buildBundle.js
@@ -29,19 +29,21 @@ async function buildBundle(
   });
 
   if (config.resolver.platforms.indexOf(args.platform) === -1) {
-    console.log(
-      chalk.red(
-        [
-          `Invalid platform ${
-            args.platform ? `(${args.platform}) ` : ''
-          }selected.`,
-          'Available platforms are:',
-          config.resolver.platforms.join(', '),
-          'If you are trying to bundle for an out-of-tree platform, it may not be installed.',
-        ].join('\n'),
-      ),
+    logger.error(
+      `Invalid platform ${
+        args.platform ? `"${chalk.bold(args.platform)}" ` : ''
+      }selected.`,
     );
-    throw new Error('Invalid platform selected.');
+
+    logger.info(
+      `Available platforms are: ${config.resolver.platforms
+        .map(x => `"${chalk.bold(x)}"`)
+        .join(
+          ', ',
+        )}. If you are trying to bundle for an out-of-tree platform, it may not be installed.`,
+    );
+
+    throw new Error('Bundling failed');
   }
 
   // This is used by a bazillion of npm modules we don't control so we don't


### PR DESCRIPTION
Summary:
---------

This pull request adds a new error message to the `react-native bundle` command that will throw an error if an invalid platform is passed to the `--platform` command, instead of failing with cryptic Haste errors.

The error message looks like this:

```
> react-native bundle --entry-file index.js --platform foo --bundle-output test.jsbundle
Invalid platform (foo) selected.
Available platforms are:
ios, android, native
If you are trying to bundle for an out-of-tree platform, it may not be installed.
error Invalid platform selected.
```


Test Plan:
----------

If you provide a platform that is not installed to `react-native bundle`, it will throw this error. If you provide a valid platform, it will continue bundling without issue.