### PR TITLE
Refactor: Rework PackageManager implementation

### DIFF
--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -19,6 +19,7 @@ import init from './commands/init/init';
 import assertRequiredOptions from './tools/assertRequiredOptions';
 import logger from './tools/logger';
 import findPlugins from './tools/findPlugins';
+import {setProjectDir} from './tools/PackageManager';
 import pkgJson from '../package.json';
 
 commander
@@ -188,6 +189,8 @@ async function setupAndRun() {
     reactNativePath,
     root,
   };
+
+  setProjectDir(ctx.root);
 
   const commands = getCommands(ctx.root);
 

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -13,7 +13,8 @@ import path from 'path';
 import process from 'process';
 import printRunInstructions from '../../tools/generator/printRunInstructions';
 import {createProjectFromTemplate} from '../../tools/generator/templates';
-import PackageManager from '../../tools/PackageManager';
+import * as PackageManager from '../../tools/PackageManager';
+import {isProjectUsingYarn} from '../../tools/yarn';
 import logger from '../../tools/logger';
 
 /**
@@ -52,10 +53,9 @@ function generateProject(destinationRoot, newProjectName, options) {
   const pkgJson = require('react-native/package.json');
   const reactVersion = pkgJson.peerDependencies.react;
 
-  const packageManager = new PackageManager({
-    projectDir: destinationRoot,
-    forceNpm: options.npm,
-  });
+  const packageManagerOptions = {
+    preferYarn: options.npm || isProjectUsingYarn(destinationRoot),
+  };
 
   createProjectFromTemplate(
     destinationRoot,
@@ -65,17 +65,20 @@ function generateProject(destinationRoot, newProjectName, options) {
   );
 
   logger.info('Adding required dependencies');
-  packageManager.install([`react@${reactVersion}`]);
+  PackageManager.install([`react@${reactVersion}`], packageManagerOptions);
 
   logger.info('Adding required dev dependencies');
-  packageManager.installDev([
-    '@babel/core',
-    '@babel/runtime',
-    'jest',
-    'babel-jest',
-    'metro-react-native-babel-preset',
-    `react-test-renderer@${reactVersion}`,
-  ]);
+  PackageManager.installDev(
+    [
+      '@babel/core',
+      '@babel/runtime',
+      'jest',
+      'babel-jest',
+      'metro-react-native-babel-preset',
+      `react-test-renderer@${reactVersion}`,
+    ],
+    packageManagerOptions,
+  );
 
   addJestToPackageJson(destinationRoot);
   printRunInstructions(destinationRoot, newProjectName);

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -14,7 +14,6 @@ import process from 'process';
 import printRunInstructions from '../../tools/generator/printRunInstructions';
 import {createProjectFromTemplate} from '../../tools/generator/templates';
 import * as PackageManager from '../../tools/PackageManager';
-import {isProjectUsingYarn} from '../../tools/yarn';
 import logger from '../../tools/logger';
 
 /**
@@ -53,10 +52,6 @@ function generateProject(destinationRoot, newProjectName, options) {
   const pkgJson = require('react-native/package.json');
   const reactVersion = pkgJson.peerDependencies.react;
 
-  const packageManagerOptions = {
-    preferYarn: !options.npm && isProjectUsingYarn(destinationRoot),
-  };
-
   createProjectFromTemplate(
     destinationRoot,
     newProjectName,
@@ -65,20 +60,17 @@ function generateProject(destinationRoot, newProjectName, options) {
   );
 
   logger.info('Adding required dependencies');
-  PackageManager.install([`react@${reactVersion}`], packageManagerOptions);
+  PackageManager.install([`react@${reactVersion}`]);
 
   logger.info('Adding required dev dependencies');
-  PackageManager.installDev(
-    [
-      '@babel/core',
-      '@babel/runtime',
-      'jest',
-      'babel-jest',
-      'metro-react-native-babel-preset',
-      `react-test-renderer@${reactVersion}`,
-    ],
-    packageManagerOptions,
-  );
+  PackageManager.installDev([
+    '@babel/core',
+    '@babel/runtime',
+    'jest',
+    'babel-jest',
+    'metro-react-native-babel-preset',
+    `react-test-renderer@${reactVersion}`,
+  ]);
 
   addJestToPackageJson(destinationRoot);
   printRunInstructions(destinationRoot, newProjectName);

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -54,7 +54,7 @@ function generateProject(destinationRoot, newProjectName, options) {
   const reactVersion = pkgJson.peerDependencies.react;
 
   const packageManagerOptions = {
-    preferYarn: options.npm || isProjectUsingYarn(destinationRoot),
+    preferYarn: !options.npm && isProjectUsingYarn(destinationRoot),
   };
 
   createProjectFromTemplate(

--- a/packages/cli/src/commands/install/install.js
+++ b/packages/cli/src/commands/install/install.js
@@ -10,16 +10,13 @@
 import type {ContextT} from '../../tools/types.flow';
 import logger from '../../tools/logger';
 import * as PackageManager from '../../tools/PackageManager';
-import {isProjectUsingYarn} from '../../tools/yarn';
 import link from '../link/link';
 
 async function install(args: Array<string>, ctx: ContextT) {
   const name = args[0];
 
   logger.info(`Installing "${name}"...`);
-  PackageManager.install([name], {
-    preferYarn: isProjectUsingYarn(ctx.root),
-  });
+  PackageManager.install([name]);
 
   logger.info(`Linking "${name}"...`);
   await link.func([name], ctx, {platforms: undefined});

--- a/packages/cli/src/commands/install/install.js
+++ b/packages/cli/src/commands/install/install.js
@@ -9,14 +9,17 @@
 
 import type {ContextT} from '../../tools/types.flow';
 import logger from '../../tools/logger';
-import PackageManager from '../../tools/PackageManager';
+import * as PackageManager from '../../tools/PackageManager';
+import {isProjectUsingYarn} from '../../tools/yarn';
 import link from '../link/link';
 
 async function install(args: Array<string>, ctx: ContextT) {
   const name = args[0];
 
   logger.info(`Installing "${name}"...`);
-  new PackageManager({projectDir: ctx.root}).install([name]);
+  PackageManager.install([name], {
+    preferYarn: isProjectUsingYarn(ctx.root),
+  });
 
   logger.info(`Linking "${name}"...`);
   await link.func([name], ctx, {platforms: undefined});

--- a/packages/cli/src/commands/install/uninstall.js
+++ b/packages/cli/src/commands/install/uninstall.js
@@ -10,7 +10,6 @@
 import type {ContextT} from '../../tools/types.flow';
 import logger from '../../tools/logger';
 import * as PackageManager from '../../tools/PackageManager';
-import {isProjectUsingYarn} from '../../tools/yarn';
 import link from '../link/unlink';
 
 async function uninstall(args: Array<string>, ctx: ContextT) {
@@ -20,9 +19,7 @@ async function uninstall(args: Array<string>, ctx: ContextT) {
   await link.func([name], ctx);
 
   logger.info(`Uninstalling "${name}"...`);
-  PackageManager.uninstall([name], {
-    preferYarn: isProjectUsingYarn(ctx.root),
-  });
+  PackageManager.uninstall([name]);
 
   logger.success(`Successfully uninstalled and unlinked "${name}"`);
 }

--- a/packages/cli/src/commands/install/uninstall.js
+++ b/packages/cli/src/commands/install/uninstall.js
@@ -9,7 +9,8 @@
 
 import type {ContextT} from '../../tools/types.flow';
 import logger from '../../tools/logger';
-import PackageManager from '../../tools/PackageManager';
+import * as PackageManager from '../../tools/PackageManager';
+import {isProjectUsingYarn} from '../../tools/yarn';
 import link from '../link/unlink';
 
 async function uninstall(args: Array<string>, ctx: ContextT) {
@@ -19,7 +20,9 @@ async function uninstall(args: Array<string>, ctx: ContextT) {
   await link.func([name], ctx);
 
   logger.info(`Uninstalling "${name}"...`);
-  new PackageManager({projectDir: ctx.root}).uninstall([name]);
+  PackageManager.uninstall([name], {
+    preferYarn: isProjectUsingYarn(ctx.root),
+  });
 
   logger.success(`Successfully uninstalled and unlinked "${name}"`);
 }

--- a/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
+++ b/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
@@ -32,13 +32,11 @@ jest.mock(
   () => ({name: 'TestApp', dependencies: {'react-native': '^0.57.8'}}),
   {virtual: true},
 );
-jest.mock('../../../tools/PackageManager', () =>
-  jest.fn(() => ({
-    install: args => {
-      mockPushLog('$ yarn add', ...args);
-    },
-  })),
-);
+jest.mock('../../../tools/PackageManager', () => ({
+  install: args => {
+    mockPushLog('$ yarn add', ...args);
+  },
+}));
 jest.mock('../helpers', () => ({
   ...jest.requireActual('../helpers'),
   fetch: jest.fn(() => Promise.resolve('patch')),

--- a/packages/cli/src/commands/upgrade/upgrade.js
+++ b/packages/cli/src/commands/upgrade/upgrade.js
@@ -6,7 +6,8 @@ import semver from 'semver';
 import execa from 'execa';
 import type {ContextT} from '../../tools/types.flow';
 import logger from '../../tools/logger';
-import PackageManager from '../../tools/PackageManager';
+import * as PackageManager from '../../tools/PackageManager';
+import {isProjectUsingYarn} from '../../tools/yarn';
 import {fetch} from './helpers';
 import legacyUpgrade from './legacyUpgrade';
 
@@ -109,12 +110,14 @@ const installDeps = async (newVersion, projectDir) => {
     `Installing "react-native@${newVersion}" and its peer dependencies...`,
   );
   const peerDeps = await getRNPeerDeps(newVersion);
-  const pm = new PackageManager({projectDir});
   const deps = [
     `react-native@${newVersion}`,
     ...Object.keys(peerDeps).map(module => `${module}@${peerDeps[module]}`),
   ];
-  await pm.install(deps, {silent: true});
+  PackageManager.install(deps, {
+    silent: true,
+    preferYarn: isProjectUsingYarn(projectDir),
+  });
   await execa('git', ['add', 'package.json']);
   try {
     await execa('git', ['add', 'yarn.lock']);

--- a/packages/cli/src/commands/upgrade/upgrade.js
+++ b/packages/cli/src/commands/upgrade/upgrade.js
@@ -116,7 +116,6 @@ const installDeps = async (newVersion, projectDir) => {
   ];
   PackageManager.install(deps, {
     silent: true,
-    preferYarn: isProjectUsingYarn(projectDir),
   });
   await execa('git', ['add', 'package.json']);
   try {

--- a/packages/cli/src/commands/upgrade/upgrade.js
+++ b/packages/cli/src/commands/upgrade/upgrade.js
@@ -7,7 +7,6 @@ import execa from 'execa';
 import type {ContextT} from '../../tools/types.flow';
 import logger from '../../tools/logger';
 import * as PackageManager from '../../tools/PackageManager';
-import {isProjectUsingYarn} from '../../tools/yarn';
 import {fetch} from './helpers';
 import legacyUpgrade from './legacyUpgrade';
 

--- a/packages/cli/src/tools/PackageManager.js
+++ b/packages/cli/src/tools/PackageManager.js
@@ -1,41 +1,52 @@
 // @flow
 import {execSync} from 'child_process';
-import {getYarnVersionIfAvailable} from './yarn';
+import {getYarnVersionIfAvailable, isProjectUsingYarn} from './yarn';
 
-type Options = {
-  preferYarn: boolean,
+type Options = {|
+  preferYarn?: boolean,
   silent?: boolean,
-};
+|};
 
-function executeCommand(command: string, silent?: boolean = false) {
+let projectDir;
+
+function executeCommand(command: string, options?: Options) {
   return execSync(command, {
-    stdio: silent ? 'pipe' : 'inherit',
+    stdio: options && options.silent ? 'pipe' : 'inherit',
   });
 }
 
-export function shouldUseYarn(preferYarn: boolean) {
-  return preferYarn && getYarnVersionIfAvailable();
+function shouldUseYarn(options?: Options) {
+  if (options && options.preferYarn !== undefined) {
+    return options.preferYarn && getYarnVersionIfAvailable();
+  }
+
+  return isProjectUsingYarn(projectDir) && getYarnVersionIfAvailable();
 }
 
-export function install(packageNames: Array<string>, options: Options) {
-  return shouldUseYarn(options.preferYarn)
-    ? executeCommand(`yarn add ${packageNames.join(' ')}`, options.silent)
+export function setProjectDir(dir: string) {
+  projectDir = dir;
+}
+
+export function install(packageNames: Array<string>, options?: Options) {
+  return shouldUseYarn(options)
+    ? executeCommand(`yarn add ${packageNames.join(' ')}`, options)
     : executeCommand(
         `npm install ${packageNames.join(' ')} --save --save-exact`,
-        options.silent,
+        options,
       );
 }
 
-export function installDev(packageNames: Array<string>, options: Options) {
-  return shouldUseYarn(options.preferYarn)
-    ? executeCommand(`yarn add -D ${packageNames.join(' ')}`)
+export function installDev(packageNames: Array<string>, options?: Options) {
+  return shouldUseYarn(options)
+    ? executeCommand(`yarn add -D ${packageNames.join(' ')}`, options)
     : executeCommand(
         `npm install ${packageNames.join(' ')} --save-dev --save-exact`,
+        options,
       );
 }
 
-export function uninstall(packageNames: Array<string>, options: Options) {
-  return shouldUseYarn(options.preferYarn)
-    ? executeCommand(`yarn remove ${packageNames.join(' ')}`)
-    : executeCommand(`npm uninstall ${packageNames.join(' ')} --save`);
+export function uninstall(packageNames: Array<string>, options?: Options) {
+  return shouldUseYarn(options)
+    ? executeCommand(`yarn remove ${packageNames.join(' ')}`, options)
+    : executeCommand(`npm uninstall ${packageNames.join(' ')} --save`, options);
 }

--- a/packages/cli/src/tools/__tests__/PackageManager-test.js
+++ b/packages/cli/src/tools/__tests__/PackageManager-test.js
@@ -1,9 +1,7 @@
 // @flow
 import ChildProcess from 'child_process';
-import PackageManager from '../PackageManager';
-import yarn from '../yarn';
-
-const PROJECT_DIR = '/project/directory';
+import * as PackageManager from '../PackageManager';
+import * as yarn from '../yarn';
 const PACKAGES = ['react', 'react-native'];
 const EXEC_OPTS = {stdio: 'inherit'};
 
@@ -16,13 +14,10 @@ describe('yarn', () => {
     jest
       .spyOn(yarn, 'getYarnVersionIfAvailable')
       .mockImplementation(() => true);
-    jest.spyOn(yarn, 'isGlobalCliUsingYarn').mockImplementation(() => true);
   });
 
   it('should install', () => {
-    const packageManager = new PackageManager({projectDir: PROJECT_DIR});
-
-    packageManager.install(PACKAGES);
+    PackageManager.install(PACKAGES, {preferYarn: true});
 
     expect(ChildProcess.execSync).toHaveBeenCalledWith(
       'yarn add react react-native',
@@ -31,9 +26,7 @@ describe('yarn', () => {
   });
 
   it('should installDev', () => {
-    const packageManager = new PackageManager({projectDir: PROJECT_DIR});
-
-    packageManager.installDev(PACKAGES);
+    PackageManager.installDev(PACKAGES, {preferYarn: true});
 
     expect(ChildProcess.execSync).toHaveBeenCalledWith(
       'yarn add -D react react-native',
@@ -42,9 +35,7 @@ describe('yarn', () => {
   });
 
   it('should uninstall', () => {
-    const packageManager = new PackageManager({projectDir: PROJECT_DIR});
-
-    packageManager.uninstall(PACKAGES);
+    PackageManager.uninstall(PACKAGES, {preferYarn: true});
 
     expect(ChildProcess.execSync).toHaveBeenCalledWith(
       'yarn remove react react-native',
@@ -55,12 +46,7 @@ describe('yarn', () => {
 
 describe('npm', () => {
   it('should install', () => {
-    const packageManager = new PackageManager({
-      projectDir: PROJECT_DIR,
-      forceNpm: true,
-    });
-
-    packageManager.install(PACKAGES);
+    PackageManager.install(PACKAGES, {preferYarn: false});
 
     expect(ChildProcess.execSync).toHaveBeenCalledWith(
       'npm install react react-native --save --save-exact',
@@ -69,12 +55,7 @@ describe('npm', () => {
   });
 
   it('should installDev', () => {
-    const packageManager = new PackageManager({
-      projectDir: PROJECT_DIR,
-      forceNpm: true,
-    });
-
-    packageManager.installDev(PACKAGES);
+    PackageManager.installDev(PACKAGES, {preferYarn: false});
 
     expect(ChildProcess.execSync).toHaveBeenCalledWith(
       'npm install react react-native --save-dev --save-exact',
@@ -83,12 +64,7 @@ describe('npm', () => {
   });
 
   it('should uninstall', () => {
-    const packageManager = new PackageManager({
-      projectDir: PROJECT_DIR,
-      forceNpm: true,
-    });
-
-    packageManager.uninstall(PACKAGES);
+    PackageManager.uninstall(PACKAGES, {preferYarn: false});
 
     expect(ChildProcess.execSync).toHaveBeenCalledWith(
       'npm uninstall react react-native --save',
@@ -99,21 +75,7 @@ describe('npm', () => {
 
 it('should use npm if yarn is not available', () => {
   jest.spyOn(yarn, 'getYarnVersionIfAvailable').mockImplementation(() => false);
-  const packageManager = new PackageManager({projectDir: PROJECT_DIR});
-
-  packageManager.install(PACKAGES);
-
-  expect(ChildProcess.execSync).toHaveBeenCalledWith(
-    'npm install react react-native --save --save-exact',
-    EXEC_OPTS,
-  );
-});
-
-it('should use npm if global cli is not using yarn', () => {
-  jest.spyOn(yarn, 'isGlobalCliUsingYarn').mockImplementation(() => false);
-  const packageManager = new PackageManager({projectDir: PROJECT_DIR});
-
-  packageManager.install(PACKAGES);
+  PackageManager.install(PACKAGES, {preferYarn: true});
 
   expect(ChildProcess.execSync).toHaveBeenCalledWith(
     'npm install react react-native --save --save-exact',

--- a/packages/cli/src/tools/__tests__/PackageManager-test.js
+++ b/packages/cli/src/tools/__tests__/PackageManager-test.js
@@ -2,8 +2,10 @@
 import ChildProcess from 'child_process';
 import * as PackageManager from '../PackageManager';
 import * as yarn from '../yarn';
+
 const PACKAGES = ['react', 'react-native'];
 const EXEC_OPTS = {stdio: 'inherit'};
+const PROJECT_ROOT = '/some/dir';
 
 beforeEach(() => {
   jest.spyOn(ChildProcess, 'execSync').mockImplementation(() => {});
@@ -81,4 +83,30 @@ it('should use npm if yarn is not available', () => {
     'npm install react react-native --save --save-exact',
     EXEC_OPTS,
   );
+});
+
+it('should use npm if project is not using yarn', () => {
+  jest.spyOn(yarn, 'isProjectUsingYarn').mockImplementation(() => false);
+
+  PackageManager.setProjectDir(PROJECT_ROOT);
+  PackageManager.install(PACKAGES);
+
+  expect(ChildProcess.execSync).toHaveBeenCalledWith(
+    'npm install react react-native --save --save-exact',
+    EXEC_OPTS,
+  );
+  expect(yarn.isProjectUsingYarn).toHaveBeenCalledWith(PROJECT_ROOT);
+});
+
+it('should use yarn if project is using yarn', () => {
+  jest.spyOn(yarn, 'isProjectUsingYarn').mockImplementation(() => false);
+
+  PackageManager.setProjectDir(PROJECT_ROOT);
+  PackageManager.install(PACKAGES);
+
+  expect(ChildProcess.execSync).toHaveBeenCalledWith(
+    'yarn add react react-native',
+    EXEC_OPTS,
+  );
+  expect(yarn.isProjectUsingYarn).toHaveBeenCalledWith(PROJECT_ROOT);
 });

--- a/packages/cli/src/tools/generator/templates.js
+++ b/packages/cli/src/tools/generator/templates.js
@@ -14,7 +14,6 @@ import path from 'path';
 import copyProjectTemplateAndReplace from './copyProjectTemplateAndReplace';
 import logger from '../logger';
 import * as PackageManager from '../PackageManager';
-import {isProjectUsingYarn} from '../yarn';
 
 /**
  * @param destPath Create the new project at this path.
@@ -74,9 +73,7 @@ function createFromRemoteTemplate(
   // Check if the template exists
   logger.info(`Fetching template ${installPackage}...`);
   try {
-    PackageManager.install([installPackage], {
-      preferYarn: isProjectUsingYarn(destinationRoot),
-    });
+    PackageManager.install([installPackage]);
     const templatePath = path.resolve('node_modules', templateName);
     copyProjectTemplateAndReplace(templatePath, destPath, newProjectName, {
       // Every template contains a dummy package.json file included
@@ -94,9 +91,7 @@ function createFromRemoteTemplate(
   } finally {
     // Clean up the temp files
     try {
-      PackageManager.uninstall([templateName], {
-        preferYarn: isProjectUsingYarn(destinationRoot),
-      });
+      PackageManager.uninstall([templateName]);
     } catch (err) {
       // Not critical but we still want people to know and report
       // if this the clean up fails.
@@ -129,9 +124,7 @@ function installTemplateDependencies(templatePath, destinationRoot) {
   const dependenciesToInstall = Object.keys(dependencies).map(
     depName => `${depName}@${dependencies[depName]}`,
   );
-  PackageManager.install(dependenciesToInstall, {
-    preferYarn: isProjectUsingYarn(destinationRoot),
-  });
+  PackageManager.install(dependenciesToInstall);
   logger.info("Linking native dependencies into the project's build files...");
   execSync('react-native link', {stdio: 'inherit'});
 }
@@ -161,9 +154,7 @@ function installTemplateDevDependencies(templatePath, destinationRoot) {
   const dependenciesToInstall = Object.keys(dependencies).map(
     depName => `${depName}@${dependencies[depName]}`,
   );
-  PackageManager.installDev(dependenciesToInstall, {
-    preferYarn: isProjectUsingYarn(destinationRoot),
-  });
+  PackageManager.installDev(dependenciesToInstall);
 }
 
 export {createProjectFromTemplate};

--- a/packages/cli/src/tools/generator/templates.js
+++ b/packages/cli/src/tools/generator/templates.js
@@ -13,7 +13,8 @@ import fs from 'fs';
 import path from 'path';
 import copyProjectTemplateAndReplace from './copyProjectTemplateAndReplace';
 import logger from '../logger';
-import PackageManager from '../PackageManager';
+import * as PackageManager from '../PackageManager';
+import {isProjectUsingYarn} from '../yarn';
 
 /**
  * @param destPath Create the new project at this path.
@@ -72,9 +73,10 @@ function createFromRemoteTemplate(
 
   // Check if the template exists
   logger.info(`Fetching template ${installPackage}...`);
-  const packageManager = new PackageManager({projectDir: destinationRoot});
   try {
-    packageManager.install([installPackage]);
+    PackageManager.install([installPackage], {
+      preferYarn: isProjectUsingYarn(destinationRoot),
+    });
     const templatePath = path.resolve('node_modules', templateName);
     copyProjectTemplateAndReplace(templatePath, destPath, newProjectName, {
       // Every template contains a dummy package.json file included
@@ -92,7 +94,9 @@ function createFromRemoteTemplate(
   } finally {
     // Clean up the temp files
     try {
-      packageManager.uninstall([templateName]);
+      PackageManager.uninstall([templateName], {
+        preferYarn: isProjectUsingYarn(destinationRoot),
+      });
     } catch (err) {
       // Not critical but we still want people to know and report
       // if this the clean up fails.
@@ -125,9 +129,9 @@ function installTemplateDependencies(templatePath, destinationRoot) {
   const dependenciesToInstall = Object.keys(dependencies).map(
     depName => `${depName}@${dependencies[depName]}`,
   );
-  new PackageManager({projectDir: destinationRoot}).install(
-    dependenciesToInstall,
-  );
+  PackageManager.install(dependenciesToInstall, {
+    preferYarn: isProjectUsingYarn(destinationRoot),
+  });
   logger.info("Linking native dependencies into the project's build files...");
   execSync('react-native link', {stdio: 'inherit'});
 }
@@ -157,9 +161,9 @@ function installTemplateDevDependencies(templatePath, destinationRoot) {
   const dependenciesToInstall = Object.keys(dependencies).map(
     depName => `${depName}@${dependencies[depName]}`,
   );
-  new PackageManager({projectDir: destinationRoot}).installDev(
-    dependenciesToInstall,
-  );
+  PackageManager.installDev(dependenciesToInstall, {
+    preferYarn: isProjectUsingYarn(destinationRoot),
+  });
 }
 
 export {createProjectFromTemplate};

--- a/packages/cli/src/tools/yarn.js
+++ b/packages/cli/src/tools/yarn.js
@@ -17,7 +17,7 @@ import logger from './logger';
  * Use Yarn if available, it's much faster than the npm client.
  * Return the version of yarn installed on the system, null if yarn is not available.
  */
-function getYarnVersionIfAvailable() {
+export function getYarnVersionIfAvailable() {
   let yarnVersion;
   try {
     // execSync returns a Buffer -> convert to string
@@ -48,11 +48,6 @@ function getYarnVersionIfAvailable() {
  * Let's be safe and not mix yarn and npm in a single project.
  * @param projectDir e.g. /Users/martin/AwesomeApp
  */
-function isGlobalCliUsingYarn(projectDir) {
+export function isProjectUsingYarn(projectDir) {
   return fs.existsSync(path.join(projectDir, 'yarn.lock'));
 }
-
-export default {
-  getYarnVersionIfAvailable,
-  isGlobalCliUsingYarn,
-};


### PR DESCRIPTION
Summary:
---------

Removed nasty `class`, and replaced it with grouped methods.

`projectDir` is always the same in `cli` lifecycle, so we set it once on the start. Based on the presence of `yarn.lock` we decide either to use yarn or not to use it. `preferYarn` is overriding this behavior, and can later be used in `init` command which lacks correct `projectDir`.

Test Plan:
----------

- [x] - Unit tests passing
- [x] - Manual testing
