### PR TITLE
Add hint for browser extensions that may break debug

### DIFF
--- a/packages/cli/src/commands/server/middleware/getSecurityHeadersMiddleware.js
+++ b/packages/cli/src/commands/server/middleware/getSecurityHeadersMiddleware.js
@@ -16,7 +16,13 @@ export default function getSecurityHeadersMiddleware(req, res, next) {
     req.headers.origin &&
     req.headers.origin !== `http://localhost:${address.port}`
   ) {
-    next(new Error('Unauthorized request from ' + req.headers.origin + '. This may happen because of a conflicting browser extension. Please try to disable it and try again.'));
+    next(
+      new Error(
+        'Unauthorized request from ' +
+          req.headers.origin +
+          '. This may happen because of a conflicting browser extension. Please try to disable it and try again.',
+      ),
+    );
     return;
   }
 

--- a/packages/cli/src/commands/server/middleware/getSecurityHeadersMiddleware.js
+++ b/packages/cli/src/commands/server/middleware/getSecurityHeadersMiddleware.js
@@ -16,7 +16,7 @@ export default function getSecurityHeadersMiddleware(req, res, next) {
     req.headers.origin &&
     req.headers.origin !== `http://localhost:${address.port}`
   ) {
-    next(new Error('Unauthorized'));
+    next(new Error('Unauthorized request from ' + req.headers.origin + '. If you have no idea what this is, it may come from some browser extensions. Stop them and try again.'));
     return;
   }
 

--- a/packages/cli/src/commands/server/middleware/getSecurityHeadersMiddleware.js
+++ b/packages/cli/src/commands/server/middleware/getSecurityHeadersMiddleware.js
@@ -16,7 +16,7 @@ export default function getSecurityHeadersMiddleware(req, res, next) {
     req.headers.origin &&
     req.headers.origin !== `http://localhost:${address.port}`
   ) {
-    next(new Error('Unauthorized request from ' + req.headers.origin + '. If you have no idea what this is, it may come from some browser extensions. Stop them and try again.'));
+    next(new Error('Unauthorized request from ' + req.headers.origin + '. This may happen because of a conflicting browser extension. Please try to disable it and try again.'));
     return;
   }
 


### PR DESCRIPTION
Some chrome extensions like this would [add custom origin](https://github.com/vitvad/Access-Control-Allow-Origin/issues/45) which break debug.