### PR TITLE
fix: pass `--projectRoot` argument to Metro

### DIFF
--- a/packages/cli/src/commands/server/runServer.js
+++ b/packages/cli/src/commands/server/runServer.js
@@ -51,6 +51,7 @@ async function runServer(argv: Array<string>, ctx: ContextT, args: Args) {
     port: args.port,
     resetCache: args.resetCache,
     watchFolders: args.watchFolders,
+    projectRoot: ctx.root,
     sourceExts: args.sourceExts,
     reporter,
   });

--- a/packages/cli/src/tools/loadMetroConfig.js
+++ b/packages/cli/src/tools/loadMetroConfig.js
@@ -73,6 +73,7 @@ export const getDefaultConfig = (ctx: ContextT) => {
 export type ConfigOptionsT = {|
   maxWorkers?: number,
   port?: number,
+  projectRoot?: string,
   resetCache?: boolean,
   watchFolders?: string[],
   sourceExts?: string[],
@@ -85,20 +86,8 @@ export type ConfigOptionsT = {|
  *
  * This allows the CLI to always overwrite the file settings.
  */
-export default (async function load(
-  ctx: ContextT,
-  // $FlowFixMe - troubles with empty object being inexact
-  options?: ConfigOptionsT = {},
-) {
+export default function load(ctx: ContextT, options?: ConfigOptionsT) {
   const defaultConfig = getDefaultConfig(ctx);
 
-  const config = await loadConfig(
-    {
-      cwd: ctx.root,
-      ...options,
-    },
-    defaultConfig,
-  );
-
-  return config;
-});
+  return loadConfig({cwd: ctx.root, ...options}, defaultConfig);
+}


### PR DESCRIPTION
Despite https://github.com/react-native-community/react-native-cli/pull/234 the `--projectRoot` argument is ignored when running the `react-native start` command as reported in https://github.com/react-native-community/react-native-cli/issues/246. The root of the issue is probably that the value is called multiple things like `root` and `projectRoot`. This PR fixes the immediate issue, but seems to be ripe for a refactor as tracked in https://github.com/react-native-community/react-native-cli/issues/246.