### PR TITLE
fix: set project directory to install packages in init command

### DIFF
--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -52,6 +52,7 @@ function generateProject(destinationRoot, newProjectName, options) {
   const pkgJson = require('react-native/package.json');
   const reactVersion = pkgJson.peerDependencies.react;
 
+  PackageManager.setProjectDir(destinationRoot);
   createProjectFromTemplate(
     destinationRoot,
     newProjectName,


### PR DESCRIPTION
Fixes https://github.com/react-native-community/react-native-cli/issues/260 and https://github.com/facebook/react-native/issues/24103 by setting project directory on PackageManager which is needed to check for yarn.lock file.

Summary:
---------

I'm not sure how to test this but creating new projects fail with the exception 
```
info Adding required dependencies
internal/validators.js:125
    throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type undefined
    at validateString (internal/validators.js:125:11)
    at Object.join (path.js:1147:7)
    at isProjectUsingYarn (/path/to/app/node_modules/@react-native-community/cli/build/tools/yarn.js:101:51)
    at shouldUseYarn (/path/to/app/node_modules/@react-native-community/cli/build/tools/PackageManager.js:36:39)
    at Object.install (/path/to/app/node_modules/@react-native-community/cli/build/tools/PackageManager.js:44:10)
    at generateProject (/path/to/app/node_modules/@react-native-community/cli/build/commands/init/init.js:111:18)
    at Object.init (/path/to/app/node_modules/@react-native-community/cli/build/commands/init/init.js:94:3)
    at run (/Users/xxx/.config/yarn/global/node_modules/react-native-cli/index.js:302:7)
    at createProject (/Users/xxx/.config/yarn/global/node_modules/react-native-cli/index.js:249:3)
    at init (/Users/xxx/.config/yarn/global/node_modules/react-native-cli/index.js:200:5)
```

The error seems to be stemming from passing `undefined` for `projectDir` to `path.join`. Added a line to fix this.

Test Plan:
----------

`react-native init TestProject` should not fail.
