### PR TITLE
bug: apply upgrade patch in subdirectory if necessary

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,5 @@
+// added for Jest inline snapshots to not use default Prettier config
+module.exports = {
+  bracketSpacing: false,
+  trailingComma: "all"
+}

--- a/packages/cli/src/commands/upgrade/upgrade.js
+++ b/packages/cli/src/commands/upgrade/upgrade.js
@@ -137,6 +137,7 @@ const applyPatch = async (
   tmpPatchFile: string,
 ) => {
   let filesToExclude = ['package.json'];
+  // $FlowFixMe ThenableChildProcess is incompatible with Promise
   const {stdout: relativePathFromRoot} = await execa('git', [
     'rev-parse',
     '--show-prefix',


### PR DESCRIPTION
Summary:
---------

Resolves #271 


Test Plan:
----------

1. Init a react native app on an old version at the root of a repo
2. Upgrade to latest rn version and check if it worked as expected (to avoid regression)
3. Discard upgrade changes and move the app to a subfolder
4. Try to upgrade again

I did test that between 0.59.0 and 0.59.2
