### PR TITLE
[General] [Fixed] - Fixes Xcode 10.2 simulator not found issue

### DIFF
--- a/packages/cli/src/commands/runIOS/findMatchingSimulator.js
+++ b/packages/cli/src/commands/runIOS/findMatchingSimulator.js
@@ -50,7 +50,7 @@ function findMatchingSimulator(simulators, simulatorString) {
     }
 
     // Making sure the version of the simulator is an iOS or tvOS (Removes Apple Watch, etc)
-    if (!version.startsWith('iOS') && !version.startsWith('tvOS')) {
+    if (!version.includes('iOS') && !version.includes('tvOS')) {
       continue;
     }
     if (simulatorVersion && !version.endsWith(simulatorVersion)) {


### PR DESCRIPTION
Summary:
---------

Fixes the simulator not found error prompted after Xcode 10.2 upgrade.


Test Plan:
----------

Tested on on Xcode: 10.1/10B61 and new version Xcode: 10.2/10E125

![Test](https://i.imgur.com/bkeGzx2.png)