### PR TITLE
fix: set correct peer dep of RN 0.60 for CLI@2.x

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,7 +58,7 @@
     "xmldoc": "^0.4.0"
   },
   "peerDependencies": {
-    "react-native": "^0.59.0"
+    "react-native": "^0.60.0"
   },
   "devDependencies": {
     "snapshot-diff": "^0.5.0"


### PR DESCRIPTION
Summary:
---------

Setting correct peer dep for 2.x


Test Plan:
----------

Proper peer warning :D 
