### PR TITLE
feat: point to --verbose when command fails

### DIFF
--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -35,7 +35,18 @@ commander.on('command:*', () => {
 const defaultOptParser = val => val;
 
 const handleError = err => {
-  logger.error(err.message);
+  if (commander.verbose) {
+    logger.error(err.message);
+  } else {
+    logger.error(
+      `${err.message}. ${chalk.dim(
+        `Run CLI with ${chalk.reset('--verbose')} ${chalk.dim(
+          'flag for more details.',
+        )}`,
+      )}`,
+    );
+  }
+  logger.debug(err.stack);
   process.exit(1);
 };
 


### PR DESCRIPTION
Summary:
---------

Our command error handler eats error stack and leaves the user with only a message. Example: https://github.com/react-native-community/react-native-cli/issues/273

I don't think we need to put stacks in every error out there, but we should enable them in `--verbose` mode.

Test Plan:
----------

<img width="628" alt="Screenshot 2019-04-02 at 12 49 06" src="https://user-images.githubusercontent.com/5106466/55397294-319daf00-5546-11e9-9354-7d1a6602d79f.png">

