### PR TITLE
Copy `.keystore` files as binary extensions.

### DIFF
--- a/packages/cli/src/tools/copyAndReplace.js
+++ b/packages/cli/src/tools/copyAndReplace.js
@@ -11,7 +11,7 @@ import fs from 'fs';
 import path from 'path';
 
 // Binary files, don't process these (avoid decoding as utf8)
-const binaryExtensions = ['.png', '.jar'];
+const binaryExtensions = ['.png', '.jar', '.keystore'];
 
 /**
  * Copy a file to given destination, replacing parts of its contents.


### PR DESCRIPTION
Summary:
---------

Right now the `debug.keystore` file isn't properly copied when creating a new app from source. This PR fixes it.

Test Plan:
----------

Created an app from master with this patch in place and I didn't have to manually copy the `.keystore` file.